### PR TITLE
docs: add README and expand AGENTS.md for onboarding

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,86 @@
+name: Security Scan
+
+on:
+  push:
+    branches: [master, dev]
+  pull_request:
+    branches: [master, dev]
+  schedule:
+    # Escaneo proactivo todos los lunes a las 8am UTC
+    # Detecta CVEs nuevos en deps que no tocaste esa semana
+    - cron: '0 8 * * 1'
+
+jobs:
+  trivy:
+    name: Trivy — filesystem & dependency scan
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      security-events: write # requerido para subir resultados a la pestaña Security
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # ── Escaneo principal ────────────────────────────────────────────────
+      # Escanea el filesystem completo:
+      #   - Dependencias npm/pnpm (pnpm-lock.yaml)
+      #   - Misconfigurations en archivos de config
+      #   - Secretos hardcodeados
+      #
+      # exit-code: '1' → falla el pipeline si encuentra CRITICAL o HIGH
+      # Esto bloquea merges a master/dev con vulnerabilidades graves
+      - name: Run Trivy scan
+        uses: aquasecurity/trivy-action@master
+        with:
+          scan-type: 'fs'
+          scan-ref: '.'
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+          severity: 'CRITICAL,HIGH'
+          exit-code: '1'
+          ignore-unfixed: true   # ignora CVEs sin fix disponible — ruido que no puedes resolver
+          scanners: 'vuln,secret,misconfig'
+
+      # ── Publicar resultados en GitHub Security tab ───────────────────────
+      # Se ejecuta aunque el paso anterior haya fallado (if: always())
+      # Los resultados quedan visibles en Security → Code scanning alerts
+      - name: Upload SARIF to GitHub Security
+        uses: github/codeql-action/upload-sarif@v3
+        if: always()
+        with:
+          sarif_file: 'trivy-results.sarif'
+
+  # ── Escaneo completo semanal (MEDIUM incluido, sin bloquear pipeline) ───
+  # Solo corre en el schedule — no en PRs
+  trivy-full:
+    name: Trivy — full scan (weekly)
+    runs-on: ubuntu-latest
+    if: github.event_name == 'schedule'
+
+    permissions:
+      contents: read
+      security-events: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run Trivy — full severity scan
+        uses: aquasecurity/trivy-action@master
+        with:
+          scan-type: 'fs'
+          scan-ref: '.'
+          format: 'sarif'
+          output: 'trivy-full-results.sarif'
+          severity: 'CRITICAL,HIGH,MEDIUM'
+          exit-code: '0'         # no bloquea — solo reporta
+          ignore-unfixed: false  # incluye CVEs sin fix para tener visibilidad completa
+          scanners: 'vuln,secret,misconfig'
+
+      - name: Upload full SARIF to GitHub Security
+        uses: github/codeql-action/upload-sarif@v3
+        if: always()
+        with:
+          sarif_file: 'trivy-full-results.sarif'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,3 +3,347 @@
 
 This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` before writing any code. Heed deprecation notices.
 <!-- END:nextjs-agent-rules -->
+
+---
+
+# TalachaStats — Guía para agentes de IA
+
+Este archivo define cómo trabajar en este codebase. Aplica a cualquier agente (Claude, Copilot, Cursor, etc.) y también a devs humanos que lean el CLAUDE.md.
+
+**Antes de escribir cualquier línea de código, lee esta guía completa.** Las decisiones aquí no son preferencias — son contratos que mantienen el proyecto coherente.
+
+---
+
+## 1. Orientación rápida del proyecto
+
+TalachaStats es una plataforma web para estadísticas de fútbol amateur en México. Tiene dos caras:
+
+- **Pública** (`/`, `/ranking`, `/player/[id]`, etc.) — jugadores ven sus stats y perfil
+- **Admin** (`/admin/*`) — organizadores importan datos; el narrador del Facebook Live consulta análisis pre-partido
+
+El flujo de datos central es: **Excel semanal → importación bulk → stats disponibles en la plataforma**. La mayoría de las features de escritura pasan por este pipeline.
+
+---
+
+## 2. Stack — versiones exactas
+
+No asumas versiones de tus datos de entrenamiento. Las versiones reales son:
+
+| Paquete | Versión | Notas críticas |
+|---|---|---|
+| `next` | **16.x** | App Router obligatorio. Pages Router no existe en este proyecto |
+| `react` | **19.x** | Nuevas APIs de concurrencia disponibles |
+| `drizzle-orm` | **0.45.x** | API relacional: `db.query.*` para reads con joins |
+| `zod` | **4.x** | Breaking changes vs. Zod 3 — sintaxis puede diferir de tu training data |
+| `tailwindcss` | **4.x** | Breaking changes vs. v3 — nueva config, nueva sintaxis de plugins |
+| `typescript` | **5.x** | `strict: true` obligatorio |
+
+Si necesitas saber qué hace una API específica de estas librerías, revisa `node_modules/[paquete]/README.md` o los tipos en `node_modules/[paquete]/dist/` antes de asumir.
+
+---
+
+## 3. Arquitectura — reglas no negociables
+
+### 3.1 Feature-Sliced Design (FSD)
+
+La regla de dependencias es estricta:
+
+```
+app  →  features  →  entities  →  shared
+```
+
+**Nunca al revés. Nunca entre capas del mismo nivel.**
+
+```
+✅  app/api/players/route.ts  →  entities/player/queries.ts
+✅  features/narrator-analysis/export-pdf.ts  →  lib/narrator.ts (legacy, ver §10)
+❌  entities/player/queries.ts  →  features/import-excel/
+❌  shared/lib/normalize.ts  →  entities/player/
+❌  features/standings/  →  features/narrator-analysis/
+```
+
+Si necesitas compartir lógica entre dos features, extráela a `entities/` o `shared/lib/`.
+
+### 3.2 API Routes = controladores delgados
+
+Un `route.ts` hace exactamente tres cosas y nada más:
+
+1. Parsear y validar la entrada con Zod
+2. Llamar a una función de `features/` o `entities/`
+3. Retornar `apiSuccess()` o `apiError()`
+
+```typescript
+// ✅ CORRECTO
+export async function GET(request: Request) {
+  const leagueId = new URL(request.url).searchParams.get("league_id");
+  if (!leagueId) return apiError("Falta league_id", 400);
+  const standings = await getLeagueStandings(leagueId);
+  return apiSuccess(standings);
+}
+
+// ❌ INCORRECTO — nunca pongas lógica de negocio en un route
+export async function GET(request: Request) {
+  const rows = await db.query.matches.findMany({ ... });
+  const standings = rows.reduce((acc, m) => { /* cálculo complejo */ }, {});
+  return Response.json(standings);
+}
+```
+
+### 3.3 Server Components por defecto
+
+Cada página es Server Component hasta que necesite estado interactivo. Solo entonces se agrega `"use client"`.
+
+```typescript
+// ✅ Page que muestra datos → Server Component (sin "use client")
+export default async function LeaguePage({ params }: { params: { id: string } }) {
+  const league = await getLeague(params.id);
+  return <LeagueDetail league={league} />;
+}
+
+// ✅ Formulario con estado → Client Component
+"use client";
+export function ImportWizard() {
+  const [step, setStep] = useState("upload");
+  ...
+}
+```
+
+### 3.4 Transacciones en features, no en routes ni en queries
+
+```typescript
+// features/import-excel/confirm.ts ✅
+export async function confirmImport(data: ParsedImport) {
+  return db.transaction(async (tx) => {
+    await tx.insert(players).values(...);
+    await tx.insert(playerSeasonStats).values(...);
+  });
+}
+```
+
+---
+
+## 4. Base de datos
+
+### 4.1 Dónde está el schema
+
+Todo el schema vive en `src/db/schema.ts`. Es la fuente de verdad — los tipos de DB se infieren de ahí con `$inferSelect` y `$inferInsert`. No crees tipos de DB a mano.
+
+```typescript
+// ✅ Tipos inferidos desde el schema
+export type Player    = typeof players.$inferSelect;
+export type NewPlayer = typeof players.$inferInsert;
+
+// ❌ No duplicar manualmente
+type Player = { id: string; fullName: string; ... }
+```
+
+### 4.2 Cómo hacer queries
+
+```typescript
+// Reads con joins → API relacional de Drizzle
+const result = await db.query.players.findMany({
+  with: { registrations: { with: { team: true } } },
+  where: eq(players.id, playerId),
+});
+
+// Escrituras y queries complejas → builders
+await db.insert(playerSeasonStats).values(data).onConflictDoUpdate({
+  target: [playerSeasonStats.playerId, playerSeasonStats.leagueId],
+  set: { goals: data.goals, updatedAt: new Date() },
+});
+
+// sql.raw() solo para operaciones que Drizzle no soporta — documentar por qué
+```
+
+### 4.3 Constraints clave que debes respetar
+
+| Tabla | Constraint | Significado práctico |
+|---|---|---|
+| `player_registrations` | `UNIQUE(player_id, league_id)` | Un jugador solo puede estar en un equipo por liga. Si necesitas moverlo, primero elimina el registro anterior |
+| `player_season_stats` | `UNIQUE(player_id, league_id)` | Una fila de stats por jugador por liga. Siempre hacer upsert, nunca insert directo |
+| `player_season_stats_snapshot` | `UNIQUE(player_id, league_id, jornada)` | Una snapshot por jornada. Re-importar la misma jornada sobreescribe, no duplica |
+| `team_standings_snapshot` | `UNIQUE(team_id, league_id, jornada)` | Ídem para standings |
+| `teams` | scoped a `league_id` | "Deportivo" en Liga Lunes ≠ "Deportivo" en Liga Martes. Son entidades distintas |
+
+### 4.4 Pool de conexiones
+
+El cliente de DB está en `src/db/index.ts`. Ya tiene el singleton pattern para dev y `max: 1` para producción serverless (Supabase pooler). **No instancies un Pool nuevo** en ningún otro archivo.
+
+---
+
+## 5. Normalización de texto — regla obligatoria
+
+Todo campo de texto buscable (nombres de jugadores, equipos, ligas) sigue este ciclo:
+
+| Momento | Función | Resultado |
+|---|---|---|
+| Antes de insertar en DB | `sanitizeName(raw)` | `"juan de la cruz"` — lowercase, sin espacios extra |
+| Al mostrar en UI | `titleCase(stored)` | `"Juan de la Cruz"` — capitalizado respetando partículas |
+| Búsqueda en DB | `f_unaccent() + similarity()` | fuzzy matching en PostgreSQL |
+
+**Si escribes código que inserta nombres en la DB sin pasar por `sanitizeName()`, está mal.**
+
+```typescript
+import { sanitizeName, titleCase } from "@/shared/lib/normalize";
+
+// Al guardar
+await db.insert(players).values({ fullName: sanitizeName(rawInput) });
+
+// Al mostrar
+<span>{titleCase(player.fullName)}</span>
+```
+
+---
+
+## 6. Autenticación
+
+### 6.1 Cómo leer la sesión
+
+```typescript
+// En Server Components y Layouts
+import { getSessionUser } from "@/shared/lib/auth";
+const user = await getSessionUser(); // null si no hay sesión
+
+// En API Route Handlers
+import { getSessionUserFromRequest } from "@/shared/lib/auth";
+const user = await getSessionUserFromRequest(request); // null si no hay sesión
+```
+
+### 6.2 Roles
+
+```typescript
+type SessionUser = {
+  id: string;
+  email: string;
+  name: string;
+  role: "owner" | "organizer";
+};
+
+// owner    → ve y edita todo, gestiona usuarios
+// organizer → solo sus ligas (verificar con canManageLeague())
+```
+
+### 6.3 Autorización de liga
+
+```typescript
+import { canManageLeague } from "@/shared/lib/auth";
+
+if (!canManageLeague(user, league.adminId)) {
+  return apiError("Sin permisos para esta liga", 403);
+}
+```
+
+### 6.4 Lo que NO debes hacer
+
+- No uses `cookies()` directamente en API routes — usa `getSessionUserFromRequest(request)`
+- No implementes tu propio sistema de tokens — usa `signSession` / `verifySession` de `shared/lib/session.ts`
+- No hardcodees roles en lógica de negocio — usa `user.role === "owner"` o `canManageLeague()`
+
+---
+
+## 7. Responses de API
+
+Siempre usar los helpers de `src/types/index.ts`. Nunca `Response.json()` directo.
+
+```typescript
+import { apiSuccess, apiSuccessPaginated, apiError } from "@/types";
+
+return apiSuccess(data);           // 200 { ok: true, data }
+return apiSuccess(data, 201);      // 201 al crear
+return apiSuccessPaginated(items, meta); // con paginación
+return apiError("mensaje", 400);   // 400 { ok: false, error }
+return apiError("no autorizado", 401);
+return apiError("no encontrado", 404);
+```
+
+---
+
+## 8. Convenciones de naming
+
+| Elemento | Convención | Ejemplo |
+|---|---|---|
+| Archivos de lógica | `kebab-case` | `excel-import-bulk.ts` |
+| Componentes React | `PascalCase` | `ImportWizard.tsx` |
+| Funciones exportadas | `camelCase` | `confirmBulkImport()` |
+| Schemas Zod y tipos | `PascalCase` | `CreateLeagueSchema`, `TeamStanding` |
+| Rutas API | `kebab-case` | `/api/top-scorers` |
+| Columnas DB | `snake_case` | `full_name`, `league_id` |
+| Variables locales | `camelCase` | `leagueId`, `homeScore` |
+| Ramas git | `feat/*`, `fix/*`, `chore/*` | `feat/player-profile` |
+
+---
+
+## 9. TypeScript — reglas estrictas
+
+```typescript
+// ❌ Prohibido
+function getData(id): any { ... }
+const result = value as MyType;
+
+// ✅ Correcto
+function getData(id: string): Promise<Player | null> { ... }
+// Si necesitas narrowing:
+if (isPlayer(value)) { ... }
+
+// Tipos de retorno explícitos SIEMPRE en features/ y entities/
+export async function getLeagueStandings(leagueId: string): Promise<TeamStanding[]> { ... }
+
+// En componentes React no son obligatorios (Next.js los infiere bien)
+export default function PlayerCard({ player }: { player: Player }) { ... }
+```
+
+---
+
+## 10. Deuda técnica — `src/lib/` (legacy)
+
+`src/lib/` es una capa plana que aún no ha sido migrada a FSD. Los archivos ahí son código en producción activo — no los elimines, pero tampoco crees funciones nuevas en esa carpeta.
+
+**Regla:** si tocas un archivo de `src/lib/`, migralo a la capa correcta en ese mismo PR/commit.
+
+| Archivo legacy | Destino FSD |
+|---|---|
+| `lib/excel-import-bulk.ts` | `features/import-excel/bulk.ts` |
+| `lib/excel-import.ts` | `features/import-excel/events.ts` |
+| `lib/narrator.ts` | `features/narrator-analysis/analysis.ts` |
+| `lib/standings.ts` | `features/standings/calculate.ts` |
+| `lib/stats.ts` | `features/player-stats/aggregate.ts` |
+| `lib/preview.ts` | `features/match-preview/build.ts` |
+
+---
+
+## 11. Lo que nunca debes hacer
+
+- **No instales librerías nuevas** sin justificación explícita. El stack es deliberadamente minimalista
+- **No uses `console.log`** en producción. Solo `console.error` para errores reales en el servidor
+- **No uses `sql.raw()`** salvo que Drizzle no soporte la operación — y si lo haces, comenta por qué
+- **No uses Redux, Zustand ni ningún estado global** — no hay necesidad en este proyecto
+- **No uses react-hook-form ni formik** — el proyecto es suficientemente simple sin ellas
+- **No hagas queries a la DB desde componentes de presentación** — solo desde `entities/` o `features/`
+- **No dupliques tipos** si Zod puede inferirlos con `z.infer<typeof MySchema>`
+- **No uses CSS custom** cuando Tailwind lo puede hacer — salvo `globals.css`
+- **No apliques `!important`** ni `style={{}}` inline salvo casos excepcionales documentados
+- **No mezcles `"use client"` sin necesidad** — el costo de hidratación existe
+
+---
+
+## 12. Checklist antes de hacer commit
+
+- [ ] ¿El código nuevo sigue la jerarquía FSD (app → features → entities → shared)?
+- [ ] ¿Los nombres que se insertan en DB pasan por `sanitizeName()`?
+- [ ] ¿Los API routes solo validan + llaman feature/entity + responden?
+- [ ] ¿Usé `apiSuccess` / `apiError` en lugar de `Response.json()` directo?
+- [ ] ¿Los tipos de DB se infieren con `$inferSelect` / `$inferInsert`?
+- [ ] ¿No agregué `any` ni `as SomeType` sin documentar por qué?
+- [ ] ¿Las transacciones están en `features/`, no en `route.ts`?
+- [ ] ¿Si toqué algo en `src/lib/`, lo migré a FSD?
+
+---
+
+## 13. Contexto de dominio — cosas que no son obvias
+
+- **Liga ≠ equipo**. "Deportivo" en Liga Lunes y "Deportivo" en Liga Martes son registros distintos en `teams`. Siempre filtrar por `league_id` cuando trabajes con equipos
+- **Stats tienen dos fuentes**. `player_season_stats` (de Excel, prioridad) y `match_events` (por partido, fallback). Si existen datos en `player_season_stats`, siempre se usan sobre `match_events`
+- **Snapshots son acumulados**. `player_season_stats_snapshot` guarda stats totales hasta la jornada N, no el delta de esa jornada. Para calcular goles en jornada 5: `J5.goals − J4.goals`
+- **El narrador es un usuario clave**. `/admin/analisis` y `/api/narrator` son features críticas — el narrador las usa en vivo durante el partido de Facebook
+- **Ciudades están predefinidas**. El listado de ciudades de México está en `shared/lib/cities.ts`. No hardcodees ciudades en ningún otro lugar
+- **`jornada` es un integer de negocio**, no una fecha. Representa la ronda de la liga (1, 2, 3…)

--- a/README.md
+++ b/README.md
@@ -1,36 +1,523 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# TalachaStats
 
-## Getting Started
+> Plataforma de estadísticas cross-liga para jugadores amateurs de fútbol 7 en México.  
+> Un perfil global por jugador. Todas sus ligas, todos sus goles.
 
-First, run the development server:
+---
 
-```bash
-npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
+## Índice
+
+1. [¿Qué es TalachaStats?](#1-qué-es-talachastats)
+2. [Stack tecnológico](#2-stack-tecnológico)
+3. [Arquitectura](#3-arquitectura)
+4. [Modelo de datos](#4-modelo-de-datos)
+5. [Flujos clave](#5-flujos-clave)
+6. [Setup local](#6-setup-local)
+7. [Variables de entorno](#7-variables-de-entorno)
+8. [Comandos disponibles](#8-comandos-disponibles)
+9. [Convenciones de código](#9-convenciones-de-código)
+10. [Guía para agregar una feature](#10-guía-para-agregar-una-feature)
+11. [Estado de migración arquitectónica](#11-estado-de-migración-arquitectónica)
+
+---
+
+## 1. ¿Qué es TalachaStats?
+
+TalachaStats resuelve un problema muy concreto: en las ligas de fútbol amateur locales de México, los jugadores participan en varias ligas a la vez (Liga Lunes, Liga Martes…) y las estadísticas viven en hojas de Excel desconectadas. No hay un perfil consolidado por jugador.
+
+La plataforma tiene **dos caras**:
+
+| Cara    | URL                             | Quién la usa                                      |
+| ------- | ------------------------------- | ------------------------------------------------- |
+| Pública | `/`, `/ranking`, `/player/[id]` | Jugadores, familiares, aficionados                |
+| Admin   | `/admin/*`                      | Organizadores de liga, narrador del Facebook Live |
+
+El **narrador del Facebook Live** es un usuario clave. Antes de cada partido necesita datos contextuales de los dos equipos (racha, goleadores, estadísticas). El módulo `/admin/analisis` y el endpoint `/api/narrator` están diseñados específicamente para él.
+
+---
+
+## 2. Stack tecnológico
+
+| Capa            | Tecnología                       | Notas                                 |
+| --------------- | -------------------------------- | ------------------------------------- |
+| Framework       | **Next.js 16** (App Router)      | Server Components por defecto         |
+| Base de datos   | **PostgreSQL** + **Drizzle ORM** | Hosted en Supabase                    |
+| Validación      | **Zod 4**                        | Un schema = un tipo, sin duplicación  |
+| Estilos         | **Tailwind CSS 4**               | Modo claro forzado, sin dark mode     |
+| Excel           | **ExcelJS**                      | Reemplazó a `xlsx` por CVEs críticos  |
+| PDF             | **PDFKit**                       | Exportación del análisis del narrador |
+| Lenguaje        | **TypeScript 5** (strict)        | `any` prohibido                       |
+| Package manager | **pnpm**                         |                                       |
+
+---
+
+## 3. Arquitectura
+
+El proyecto usa **Feature-Sliced Design (FSD) adaptado a Next.js full-stack**.
+
+### Regla de dependencias
+
+```
+app  →  features  →  entities  →  shared
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+Las capas superiores importan de las inferiores. **Nunca al revés, nunca entre capas del mismo nivel.**
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+```
+✅  features/narrator-analysis → entities/player
+✅  app/api/players → entities/player
+❌  entities/player → features/import-excel
+❌  shared/ → entities/
+```
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+### Estructura de carpetas
 
-## Learn More
+```
+src/
+├── app/                          # Next.js routing — solo rutas y layouts
+│   ├── (public)/                 # Cara pública (sin auth)
+│   │   ├── page.tsx              # Home — HeroSection, StatsBar, LeaderboardTeaser
+│   │   ├── ranking/              # Rankings cross-liga, filtrable por liga y ciudad
+│   │   ├── player/[id]/          # Perfil público del jugador
+│   │   ├── players/              # Directorio de jugadores
+│   │   ├── matchday/             # Página de jornada
+│   │   └── analysis/             # Vista pública de análisis
+│   ├── admin/                    # Panel admin (requiere sesión)
+│   │   ├── import/               # Wizard de importación de Excel
+│   │   ├── analisis/             # Herramienta del narrador
+│   │   ├── leagues/              # CRUD de ligas
+│   │   ├── teams/                # Vista de equipos
+│   │   ├── players/              # Gestión de jugadores
+│   │   ├── matches/              # Detalle de partido + preview
+│   │   ├── narrator/             # Panel narrador
+│   │   └── users/                # Gestión de usuarios (solo owner)
+│   ├── api/                      # Route handlers — solo validación + llamada a feature/entity
+│   │   ├── auth/                 # login, logout, me, setup
+│   │   ├── import/               # bulk, detect, templates
+│   │   ├── leagues/              # CRUD + standings, top-scorers, top-assists
+│   │   ├── matches/              # CRUD + events + preview
+│   │   ├── narrator/             # Análisis pre-partido + export PDF
+│   │   ├── players/              # CRUD + stats + search
+│   │   ├── ranking/              # Ranking cross-liga
+│   │   ├── teams/                # CRUD + roster + merge
+│   │   └── analytics/visit/      # Tracking de visitas
+│   └── login/
+│
+├── features/                     # Casos de uso completos
+│   └── narrator-analysis/
+│       ├── export-pdf.ts         # Genera PDF del análisis para el narrador
+│       └── export-png.tsx        # Exportación como imagen
+│
+├── entities/                     # Entidades de negocio puras
+│   ├── player/
+│   │   ├── model.ts              # Tipos + schemas Zod
+│   │   ├── queries.ts            # Acceso a DB (get, list, search, upsert)
+│   │   ├── ranking.ts            # Lógica de ranking cross-liga
+│   │   └── index.ts              # Re-exportaciones públicas
+│   ├── user/
+│   │   ├── model.ts
+│   │   ├── queries.ts
+│   │   └── index.ts
+│   └── analytics/
+│       └── queries.ts
+│
+├── lib/                          # ⚠️ Capa legacy — ver §11
+│   ├── excel-import.ts           # Importador event-by-event (formato antiguo)
+│   ├── excel-import-bulk.ts      # Importador bulk (goleadores + standings)
+│   ├── narrator.ts               # Análisis pre-partido
+│   ├── standings.ts              # Cálculo de tabla de posiciones
+│   ├── stats.ts                  # Agregación de stats de jugador
+│   └── preview.ts                # Preview de partido por match_id
+│
+├── shared/                       # Primitivos reutilizables
+│   ├── lib/
+│   │   ├── auth.ts               # getSessionUser() / getSessionUserFromRequest()
+│   │   ├── session.ts            # HMAC-SHA256, sign/verify, cookie helpers
+│   │   ├── normalize.ts          # sanitizeName(), titleCase()
+│   │   ├── cities.ts             # Lista de ciudades de México
+│   │   ├── active-city.ts        # Ciudad activa del admin (cookie)
+│   │   ├── pagination.ts         # Helper de paginación
+│   │   ├── excel.ts              # readWorkbook(), sheetToObjects()
+│   │   └── server-fetch.ts       # fetch con base URL resuelta en server
+│   └── ui/
+│       ├── Icon.tsx              # Wrapper de lucide-react (strokeWidth=2)
+│       ├── PublicNav.tsx         # Barra de navegación pública
+│       ├── PublicFooter.tsx      # Footer público
+│       ├── FilterBar.tsx         # Filtros reutilizables
+│       ├── LeagueSelect.tsx      # Selector de liga
+│       ├── CityFilter.tsx        # Filtro de ciudad
+│       ├── Pagination.tsx        # Paginación
+│       ├── NavigationProgress.tsx
+│       └── TrackVisit.tsx        # Beacon de visita (client component)
+│
+├── db/
+│   ├── schema.ts                 # Definición completa del schema Drizzle
+│   ├── index.ts                  # Cliente de DB + re-exportaciones
+│   ├── migrate.ts                # Script de migración manual
+│   ├── views.sql                 # Vistas SQL auxiliares
+│   └── migrations/               # Archivos SQL generados por drizzle-kit
+│
+└── types/
+    └── index.ts                  # apiSuccess(), apiError() y tipos globales
+```
 
-To learn more about Next.js, take a look at the following resources:
+---
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+## 4. Modelo de datos
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
+### Diagrama de entidades
 
-## Deploy on Vercel
+```
+users ──────────────────────────────── leagues
+  (owner | organizer)                    │
+                                         │ (scoped)
+                                       teams ────────── matches
+                                         │                │
+                           player_registrations      match_events
+                                    │
+players ────────────────────────────┘
+  │
+  ├── player_season_stats          (stats acumuladas por liga, fuente: Excel)
+  ├── player_season_stats_snapshot (historial de stats por jornada)
+  └── team_standings_snapshot      (tabla de posiciones por jornada)
+```
 
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
+### Tablas principales
 
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+| Tabla                          | Descripción                                                                                     |
+| ------------------------------ | ----------------------------------------------------------------------------------------------- |
+| `users`                        | Cuentas admin. Roles: `owner` (ve todo) / `organizer` (solo sus ligas)                          |
+| `players`                      | Identidad global del jugador — independiente de liga o equipo                                   |
+| `leagues`                      | Liga por día/torneo (`Liga Lunes`, `Liga Martes`…). Tiene `city`, `season`, `status`            |
+| `teams`                        | Equipo **siempre scoped a una liga**. "Deportivo" en Liga Lunes ≠ "Deportivo" en Liga Martes    |
+| `player_registrations`         | Pivote jugador ↔ equipo ↔ liga. `UNIQUE(player_id, league_id)` — un jugador, un equipo por liga |
+| `matches`                      | Partido entre dos equipos de la misma liga                                                      |
+| `match_events`                 | Eventos granulares: `goal`, `assist`, `yellow_card`, `red_card`, `own_goal`, `mvp`              |
+| `player_season_stats`          | Stats acumuladas importadas desde Excel. `UNIQUE(player_id, league_id)`. **Fuente primaria**    |
+| `player_season_stats_snapshot` | Historial por jornada. Permite ver progresión y corregir re-importaciones                       |
+| `team_standings_snapshot`      | Tabla de posiciones importada. `UNIQUE(team_id, league_id, jornada)`                            |
+| `import_templates`             | Plantillas de mapeo de columnas Excel → campos del sistema                                      |
+| `page_views`                   | Visitas únicas por visitor_id (UUID en cookie)                                                  |
+
+### Decisiones de diseño importantes
+
+**Stats: dos fuentes, una prioridad**
+
+Las estadísticas de un jugador pueden venir de dos fuentes:
+
+1. `player_season_stats` — importadas desde el Excel semanal del organizador _(prioridad alta)_
+2. `match_events` — registradas partido a partido _(fallback)_
+
+Cuando existen datos en `player_season_stats`, siempre se usan. Los `match_events` son el respaldo si no hay importación.
+
+**Snapshots acumulados, no deltas**
+
+`player_season_stats_snapshot` guarda stats **acumuladas** hasta la jornada N, no las de esa jornada. Para saber cuántos goles marcó alguien en la jornada 5 se calcula `J5.goals − J4.goals`. Esto permite re-importar una jornada sin romper el historial.
+
+**Normalización de nombres**
+
+Todos los campos de texto buscables (nombres de jugadores, equipos, ligas) siguen una convención estricta definida en `shared/lib/normalize.ts`:
+
+```
+Almacenamiento en BD  → sanitizeName()   (lowercase + trim + colapso de espacios)
+Display en UI         → titleCase()      (primera letra por palabra, respeta partículas)
+Búsqueda en DB        → f_unaccent() + similarity() en PostgreSQL
+```
+
+---
+
+## 5. Flujos clave
+
+### Autenticación
+
+El sistema usa sesiones propias con **HMAC-SHA256** (sin dependencias externas como NextAuth).
+
+```
+Login → POST /api/auth/login
+  → verifica email + bcrypt(password)
+  → signSession(userId) → token base64url {userId}|{expiresAt}|{hmac}
+  → Set-Cookie: ts_session (HttpOnly, SameSite=Strict, 7 días)
+
+Cada request protegido:
+  → getSessionUser()             (Server Components — lee cookies() de next/headers)
+  → getSessionUserFromRequest()  (API Routes — lee el Request directamente)
+  → verifySession(token) → confirma HMAC + expiry + user activo en DB
+```
+
+El admin layout redirige a `/login` si no hay sesión válida (segunda línea de defensa; el middleware es la primera).
+
+**Roles:**
+
+- `owner` — puede ver y editar todo, incluyendo gestión de usuarios
+- `organizer` — solo puede gestionar sus ligas (verificado con `canManageLeague()`)
+
+### Importación de Excel (flujo bulk)
+
+Es el flujo más complejo. El wizard en `/admin/import` sigue estos pasos:
+
+```
+1. Upload del .xlsx
+2. POST /api/import/bulk (action=preview)
+   → parseBulkExcel() o parseBulkExcelMapped() si hay template guardado
+   → auto-detección del tipo: "goleadores" | "standings"
+   → fuzzy matching de nombres de jugadores (sanitizeName + similarity)
+   → devuelve preview: rows parseadas + player resolutions + warnings
+
+3. El usuario resuelve ambigüedades de jugadores (nuevo vs. existente)
+
+4. POST /api/import/bulk (action=confirm)
+   → confirmBulkImport()
+   → upsert en player_season_stats (ON CONFLICT DO UPDATE)
+   → insert en player_season_stats_snapshot (historial por jornada)
+   → upsert en team_standings_snapshot
+   → todo dentro de una transacción
+```
+
+Los templates (`import_templates`) guardan el mapeo de columnas del Excel para que el organizador no tenga que reconfigurar cada semana.
+
+### Análisis pre-partido del narrador
+
+`/admin/analisis` y `GET /api/narrator?team_a={id}&team_b={id}&league_id={id}`:
+
+```
+narrator.ts recopila, en orden de prioridad:
+  1. player_season_stats   → roster + stats de cada equipo
+  2. match_events          → fallback si no hay import
+  3. team_standings_snapshot → posición, récord, forma
+  4. matches               → últimos 5 resultados + Head-to-Head
+
+Calcula por jugador:
+  → goalsPerMatch, contributions (goles + asistencias)
+  → dangerRating: ALTO / MEDIO / BAJO
+
+Devuelve NarratorAnalysis con:
+  → teamA, teamB (con roster, topScorer, topAssist, currentStreak)
+  → h2h (head-to-head histórico)
+  → keyMatchups (enfrentamientos individuales clave)
+  → generatedAt timestamp
+
+Exportación:
+  → POST /api/narrator/export → PDF generado con PDFKit (pdfkit, sin browser)
+```
+
+---
+
+## 6. Setup local
+
+### Prerrequisitos
+
+- Node.js 20+
+- pnpm
+- PostgreSQL (local o una instancia en Supabase)
+
+### Pasos
+
+```bash
+# 1. Clonar
+git clone <repo-url>
+cd talachastats
+
+# 2. Instalar dependencias
+pnpm install
+
+# 3. Configurar variables de entorno
+cp env.local.example .env.local
+# Editar .env.local con tus valores (ver §7)
+
+# 4. Correr migraciones
+pnpm db:migrate:run
+
+# 5. Crear el primer usuario owner (solo primera vez)
+# Enviar POST /api/auth/setup con { secret, email, password, name }
+# El SETUP_SECRET está en .env.local
+
+# 6. Levantar el servidor de desarrollo
+pnpm dev
+```
+
+La app corre en `http://localhost:3000`.
+
+El panel admin está en `http://localhost:3000/admin` — requiere iniciar sesión.
+
+---
+
+## 7. Variables de entorno
+
+| Variable               | Descripción                                                         | Requerida |
+| ---------------------- | ------------------------------------------------------------------- | --------- |
+| `DATABASE_URL`         | Connection string de PostgreSQL                                     | ✅        |
+| `SESSION_SECRET`       | Secreto HMAC para tokens de sesión. Mínimo 32 chars                 | ✅        |
+| `SETUP_SECRET`         | Contraseña para crear el primer usuario owner via `/api/auth/setup` | ✅        |
+| `NEXT_PUBLIC_BASE_URL` | URL base pública (ej: `https://talachastats.com`)                   | ✅        |
+
+> **Nunca** subas `.env.local` al repositorio. El `.gitignore` ya lo excluye.
+
+---
+
+## 8. Comandos disponibles
+
+```bash
+pnpm dev              # Servidor de desarrollo en localhost:3000
+pnpm build            # Build de producción
+pnpm start            # Servidor de producción (requiere build previo)
+pnpm lint             # ESLint
+
+pnpm db:generate      # Genera archivos de migración desde el schema (drizzle-kit)
+pnpm db:migrate       # Aplica migraciones (drizzle-kit push — solo desarrollo)
+pnpm db:migrate:run   # Corre el script src/db/migrate.ts (producción)
+```
+
+---
+
+## 9. Convenciones de código
+
+### Naming
+
+| Elemento            | Convención   | Ejemplo                             |
+| ------------------- | ------------ | ----------------------------------- |
+| Archivos de lógica  | `kebab-case` | `player-stats.ts`                   |
+| Componentes React   | `PascalCase` | `NarratorPanel.tsx`                 |
+| Funciones           | `camelCase`  | `getLeagueStandings()`              |
+| Tipos y schemas Zod | `PascalCase` | `PlayerStats`, `CreateLeagueSchema` |
+| Rutas API           | `kebab-case` | `/api/top-scorers`                  |
+| Columnas DB         | `snake_case` | `full_name`, `league_id`            |
+| Variables TS        | `camelCase`  | `leagueId`, `homeScore`             |
+
+### TypeScript
+
+- `strict: true` siempre
+- Prohibido `any` — usar `unknown` + narrowing
+- Prohibido `as SomeType` salvo que sea inevitable y se documente el porqué
+- Tipos de retorno explícitos en funciones de `features/` y `entities/`
+- Preferir `type` sobre `interface` (salvo que se necesite `extends`)
+
+```typescript
+// ✅ Correcto
+export async function getLeagueStandings(leagueId: string): Promise<TeamStanding[]> { ... }
+
+// ❌ Incorrecto
+export async function getLeagueStandings(leagueId) { ... }
+```
+
+### API Routes — patrón obligatorio
+
+Los `route.ts` solo hacen tres cosas: validar entrada con Zod, llamar a una función de `features/` o `entities/`, y retornar `apiSuccess` o `apiError`.
+
+```typescript
+// ✅ CORRECTO
+export async function GET(request: Request) {
+  const leagueId = new URL(request.url).searchParams.get("league_id");
+  if (!leagueId) return apiError("Falta league_id", 400);
+
+  const standings = await getLeagueStandings(leagueId);
+  return apiSuccess(standings);
+}
+
+// ❌ INCORRECTO — lógica de negocio en el route
+export async function GET(request: Request) {
+  const rows = await db.query.matches.findMany({ ... });
+  const standings = rows.reduce((acc, m) => { /* cálculo aquí */ }, {});
+  return Response.json(standings);
+}
+```
+
+### Responses
+
+```typescript
+return apiSuccess(data); // { ok: true, data }
+return apiSuccess(data, 201); // crear recurso
+return apiError("mensaje", 400); // { ok: false, error }
+return apiError("no encontrado", 404);
+```
+
+### Transacciones
+
+Las transacciones van en `features/`, nunca en `route.ts` ni en `entities/`.
+
+```typescript
+// features/import-excel/confirm.ts ✅
+export async function confirmImport(data: ParsedImport) {
+  return db.transaction(async (tx) => {
+    await tx.insert(players).values(...);
+    await tx.insert(playerSeasonStats).values(...);
+  });
+}
+```
+
+### Iconos
+
+Todos los iconos usan el componente `shared/ui/Icon.tsx` como wrapper de `lucide-react`. Los estándares son `strokeWidth=2` y tamaños de 12/16/20/24px.
+
+### Normalización de nombres
+
+Antes de insertar cualquier nombre en la DB, pasarlo por `sanitizeName()`. Para mostrarlo en la UI, usar `titleCase()`. Nunca guardar un nombre sin normalizar.
+
+---
+
+## 10. Guía para agregar una feature
+
+Seguir este orden para cualquier nueva funcionalidad:
+
+**1. Modelo** — `entities/[nombre]/model.ts`
+Define los tipos y schema Zod. Un schema = un tipo, sin duplicación.
+
+**2. Queries** — `entities/[nombre]/queries.ts`
+Acceso a DB con Drizzle. Devuelve tipos explícitos. Maneja el caso "no encontrado".
+
+**3. Lógica** — `features/[nombre]/`
+Orquesta queries, calcula, transforma. Aquí van las transacciones.
+
+**4. Endpoint** — `app/api/[ruta]/route.ts`
+Valida con Zod → llama al feature/entity → responde con `apiSuccess`/`apiError`.
+
+**5. UI** — `app/(public)/[ruta]/page.tsx` o `app/admin/[ruta]/page.tsx`
+Server Component por defecto. Client Component solo si hay estado interactivo.
+
+**6. Menú** — actualizar `app/admin/layout.tsx` si aplica.
+
+### Naming de endpoints
+
+```
+GET    /api/[recurso]            → listar
+POST   /api/[recurso]            → crear
+GET    /api/[recurso]/[id]       → detalle
+PATCH  /api/[recurso]/[id]       → actualizar parcialmente
+DELETE /api/[recurso]/[id]       → eliminar
+POST   /api/[recurso]/[accion]   → acción especial (ej: /merge, /confirm)
+```
+
+---
+
+## 11. Estado de migración arquitectónica
+
+El proyecto está en migración de una arquitectura `lib/` plana hacia FSD completo. **No hay un refactor masivo planeado** — la migración ocurre archivo por archivo cuando se toca cada módulo.
+
+| Archivo                           | Estado                              | Destino objetivo              |
+| --------------------------------- | ----------------------------------- | ----------------------------- |
+| `src/lib/excel-import-bulk.ts`    | Legacy en uso activo                | `features/import-excel/`      |
+| `src/lib/excel-import.ts`         | Legacy (formato antiguo de eventos) | `features/import-excel/`      |
+| `src/lib/narrator.ts`             | Legacy en uso activo                | `features/narrator-analysis/` |
+| `src/lib/standings.ts`            | Legacy                              | `features/standings/`         |
+| `src/lib/stats.ts`                | Legacy                              | `features/player-stats/`      |
+| `src/lib/preview.ts`              | Legacy                              | `features/match-preview/`     |
+| `src/features/narrator-analysis/` | **FSD ✅**                          | ya migrado (export)           |
+| `src/entities/player/`            | **FSD ✅**                          | ya migrado                    |
+| `src/entities/user/`              | **FSD ✅**                          | ya migrado                    |
+
+**Regla al tocar un archivo legacy:** migrarlo a la capa correcta de FSD. No crear nuevas funciones en `src/lib/`.
+
+---
+
+## Ramas de git
+
+| Rama      | Propósito                          |
+| --------- | ---------------------------------- |
+| `master`  | Producción estable                 |
+| `dev`     | Desarrollo activo — hacer PRs aquí |
+| `feat/*`  | Features nuevas                    |
+| `fix/*`   | Correcciones                       |
+| `chore/*` | Mantenimiento (deps, config)       |
+
+---
+
+_TalachaStats — Tijuana, México_

--- a/env.local.example
+++ b/env.local.example
@@ -1,0 +1,5 @@
+DATABASE_URL=postgresql://postgres:123qwe@localhost:5432/futbol_stats
+NEXT_PUBLIC_BASE_URL=http://localhost:3000
+ADMIN_PASSWORD=
+ADMIN_SESSION_TOKEN=
+SETUP_SECRET=


### PR DESCRIPTION
- Replace placeholder README with full project documentation: architecture, data model, key flows, setup, conventions, and migration status
- Rewrite AGENTS.md with AI-specific guardrails: exact package versions, FSD dependency rules, DB constraints, name normalization contract, auth patterns, and pre-commit checklist