### PR TITLE
feat(home): add organizer-focused sections and improve conversion

### DIFF
--- a/src/app/(public)/HeroSection.tsx
+++ b/src/app/(public)/HeroSection.tsx
@@ -161,6 +161,16 @@ export default function HeroSection() {
             >
               Ya hay jugadores de Tijuana en el ranking. ¿Estás tú?
             </p>
+
+            {/* Puerta para el organizador */}
+            <Link
+              href="/about#organizadores"
+              className="animate-fade-slide-up inline-flex items-center gap-1.5 text-xs text-ink-3 hover:text-brand border border-line hover:border-brand/40 px-3.5 py-2 rounded-xl transition"
+              style={{ animationDelay: "1s", animationFillMode: "both" }}
+            >
+              ¿Organizas una liga?
+              <span className="text-brand font-semibold">Ponla en el mapa →</span>
+            </Link>
           </div>
 
           {/* ── Columna derecha — HeroCard ── */}

--- a/src/app/(public)/LeaguesShowcase.tsx
+++ b/src/app/(public)/LeaguesShowcase.tsx
@@ -1,0 +1,172 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import Link from "next/link";
+import { MapPin, ChevronRight, Users, Star } from "lucide-react";
+import { titleCase } from "@/shared/lib/normalize";
+import type { LeagueShowcaseItem } from "@/entities/organization";
+
+/* ── Card individual ─────────────────────────────────────────────────────────── */
+function LeagueCardItem({ league, delay, visible }: {
+  league: LeagueShowcaseItem; delay: number; visible: boolean;
+}) {
+  const initial = league.name.charAt(0).toUpperCase();
+
+  return (
+    <div
+      className="bg-surface border border-line rounded-2xl overflow-hidden hover:border-brand/40 transition-colors group"
+      style={{
+        opacity:    visible ? 1 : 0,
+        transform:  visible ? "translateY(0)" : "translateY(24px)",
+        transition: `opacity 0.6s cubic-bezier(0.22,1,0.36,1) ${delay}ms, transform 0.6s cubic-bezier(0.22,1,0.36,1) ${delay}ms, border-color 0.2s`,
+      }}
+    >
+      {/* Header de la liga */}
+      <div className="bg-brand/5 border-b border-line px-4 py-3.5 flex items-center gap-3">
+        <div className="w-10 h-10 rounded-xl bg-brand/15 border border-brand/25 flex items-center justify-center shrink-0">
+          <span className="font-display font-black text-lg text-brand">{initial}</span>
+        </div>
+        <div className="min-w-0 flex-1">
+          <p className="font-display font-black text-base text-ink uppercase tracking-tight leading-tight truncate">
+            {league.name}
+          </p>
+          <div className="flex items-center gap-1 mt-0.5">
+            <MapPin size={10} strokeWidth={2} className="text-ink-3 shrink-0" />
+            <p className="text-[11px] text-ink-3 truncate">
+              {league.city}{league.season ? ` · ${league.season}` : ""}
+            </p>
+          </div>
+        </div>
+      </div>
+
+      {/* Stats de la liga */}
+      <div className="grid grid-cols-2 divide-x divide-line border-b border-line">
+        <div className="flex flex-col items-center py-3 gap-0.5">
+          <div className="flex items-center gap-1">
+            <Users size={10} strokeWidth={2} className="text-ink-3" />
+            <span className="font-display font-black text-2xl text-ink leading-none">
+              {league.playerCount}
+            </span>
+          </div>
+          <span className="text-[10px] text-ink-3 uppercase tracking-widest font-semibold">
+            Jugadores
+          </span>
+        </div>
+        <div className="flex flex-col items-center py-3 gap-0.5">
+          <span className="font-display font-black text-2xl text-ink leading-none">
+            {league.teamCount}
+          </span>
+          <span className="text-[10px] text-ink-3 uppercase tracking-widest font-semibold">
+            Equipos
+          </span>
+        </div>
+      </div>
+
+      {/* Goleador top */}
+      <div className="px-4 py-3 flex items-center gap-2.5">
+        <Star size={12} strokeWidth={2} className="text-brand shrink-0" />
+        <div className="min-w-0 flex-1">
+          <p className="text-[11px] text-ink-3 uppercase tracking-widest font-semibold mb-0.5">
+            Goleador
+          </p>
+          {league.topScorer ? (
+            <p className="text-sm font-semibold text-ink truncate">
+              {league.topScorer.alias
+                ? <>&quot;{titleCase(league.topScorer.alias)}&quot;</>
+                : titleCase(league.topScorer.fullName)}
+            </p>
+          ) : (
+            <p className="text-sm text-ink-3 italic truncate">Sin datos aún</p>
+          )}
+        </div>
+        {league.topScorer && (
+          <div className="text-right shrink-0">
+            <p className="font-display font-black text-xl text-brand leading-none">
+              {league.topScorer.goals}
+            </p>
+            <p className="text-[10px] text-ink-3">goles</p>
+          </div>
+        )}
+      </div>
+
+      {/* CTA */}
+      <div className="px-4 pb-3.5">
+        <Link
+          href={`/ranking?scope=league`}
+          className="flex items-center justify-center gap-1 w-full text-xs font-semibold text-ink-3 group-hover:text-brand border border-line group-hover:border-brand/30 py-2 rounded-xl transition"
+        >
+          Ver liga
+          <ChevronRight size={12} strokeWidth={2} />
+        </Link>
+      </div>
+    </div>
+  );
+}
+
+/* ── Sección completa ─────────────────────────────────────────────────────────── */
+export default function LeaguesShowcase({ leagues }: { leagues: LeagueShowcaseItem[] }) {
+  const [visible, setVisible] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    const obs = new IntersectionObserver(
+      ([entry]) => { if (entry.isIntersecting) { setVisible(true); obs.disconnect(); } },
+      { threshold: 0.1 }
+    );
+    obs.observe(el);
+    return () => obs.disconnect();
+  }, []);
+
+  if (leagues.length === 0) return null;
+
+  return (
+    <section className="bg-pitch border-t border-line px-5 py-16">
+      <div className="max-w-4xl mx-auto">
+
+        {/* Header */}
+        <div
+          className="flex flex-col sm:flex-row sm:items-end justify-between gap-4 mb-8"
+          style={{
+            opacity:    visible ? 1 : 0,
+            transform:  visible ? "translateY(0)" : "translateY(16px)",
+            transition: "opacity 0.5s ease, transform 0.5s ease",
+          }}
+        >
+          <div>
+            <p className="text-[11px] font-bold text-brand uppercase tracking-widest mb-1.5">
+              Ligas en la plataforma
+            </p>
+            <h2 className="font-display font-black text-3xl sm:text-4xl uppercase text-ink leading-tight">
+              Tu liga,<br className="sm:hidden" /> en el mapa.
+            </h2>
+            <p className="text-ink-2 text-sm mt-2 max-w-sm">
+              Estas ligas ya tienen presencia pública. Sus jugadores, sus goleadores y su historia, visibles para toda la ciudad.
+            </p>
+          </div>
+          <Link
+            href="/about#organizadores"
+            className="shrink-0 inline-flex items-center gap-1.5 text-sm font-semibold text-brand border border-brand/30 hover:bg-brand/8 px-4 py-2.5 rounded-xl transition"
+          >
+            Registra la tuya
+            <ChevronRight size={14} strokeWidth={2} />
+          </Link>
+        </div>
+
+        {/* Grid de ligas */}
+        <div ref={ref} className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+          {leagues.map((league, i) => (
+            <LeagueCardItem
+              key={league.id}
+              league={league}
+              delay={i * 100}
+              visible={visible}
+            />
+          ))}
+        </div>
+
+      </div>
+    </section>
+  );
+}

--- a/src/app/(public)/LeaguesShowcase.tsx
+++ b/src/app/(public)/LeaguesShowcase.tsx
@@ -89,16 +89,18 @@ function LeagueCardItem({ league, delay, visible }: {
         )}
       </div>
 
-      {/* CTA */}
-      <div className="px-4 pb-3.5">
-        <Link
-          href={`/ranking?scope=league`}
-          className="flex items-center justify-center gap-1 w-full text-xs font-semibold text-ink-3 group-hover:text-brand border border-line group-hover:border-brand/30 py-2 rounded-xl transition"
-        >
-          Ver liga
-          <ChevronRight size={12} strokeWidth={2} />
-        </Link>
-      </div>
+      {/* CTA — solo se muestra si hay URL real */}
+      {league.orgSlug && league.leagueSlug && (
+        <div className="px-4 pb-3.5">
+          <Link
+            href={`/org/${league.orgSlug}/${league.leagueSlug}`}
+            className="flex items-center justify-center gap-1 w-full text-xs font-semibold text-ink-3 group-hover:text-brand border border-line group-hover:border-brand/30 py-2 rounded-xl transition"
+          >
+            Ver liga
+            <ChevronRight size={12} strokeWidth={2} />
+          </Link>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/app/(public)/OrganizerSection.tsx
+++ b/src/app/(public)/OrganizerSection.tsx
@@ -1,0 +1,182 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import Link from "next/link";
+import { Globe, BarChart3, Share2, ChevronRight, CheckCircle } from "lucide-react";
+
+const VALUE_PROPS = [
+  {
+    Icon: Globe,
+    title: "Tu liga, visible para todos",
+    desc: "Página pública con el nombre de tu liga, tabla de posiciones y goleadores. Un link que puedes compartir con tus jugadores hoy mismo.",
+    delay: 80,
+  },
+  {
+    Icon: BarChart3,
+    title: "Tus jugadores en el ranking de la ciudad",
+    desc: "Los goleadores de tu liga aparecen automáticamente en el ranking cruzado de Tijuana. Tu liga pone gente en el mapa.",
+    delay: 180,
+  },
+  {
+    Icon: Share2,
+    title: "Contenido listo para compartir",
+    desc: "Cada temporada genera una tarjeta con las stats de tu liga. La compartes en tu grupo de WhatsApp o en tus redes. Sin diseño, sin esfuerzo.",
+    delay: 280,
+  },
+];
+
+const PERKS = [
+  "Sin cuotas por jugador",
+  "Un Excel semanal es todo lo que necesitas",
+  "Tus datos, tus ligas, tu crédito",
+  "Visible para jugadores de toda la ciudad",
+];
+
+function ValueCard({ Icon, title, desc, delay, visible }: {
+  Icon: typeof Globe; title: string; desc: string; delay: number; visible: boolean;
+}) {
+  return (
+    <div
+      className="flex gap-4"
+      style={{
+        opacity:    visible ? 1 : 0,
+        transform:  visible ? "translateY(0)" : "translateY(20px)",
+        transition: `opacity 0.6s cubic-bezier(0.22,1,0.36,1) ${delay}ms, transform 0.6s cubic-bezier(0.22,1,0.36,1) ${delay}ms`,
+      }}
+    >
+      <div className="w-10 h-10 rounded-xl bg-brand/10 border border-brand/20 flex items-center justify-center shrink-0 mt-0.5">
+        <Icon size={18} strokeWidth={2} className="text-brand" />
+      </div>
+      <div>
+        <p className="font-semibold text-ink text-sm mb-1">{title}</p>
+        <p className="text-ink-3 text-sm leading-relaxed">{desc}</p>
+      </div>
+    </div>
+  );
+}
+
+export default function OrganizerSection() {
+  const [visible, setVisible] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    const obs = new IntersectionObserver(
+      ([entry]) => { if (entry.isIntersecting) { setVisible(true); obs.disconnect(); } },
+      { threshold: 0.1 }
+    );
+    obs.observe(el);
+    return () => obs.disconnect();
+  }, []);
+
+  return (
+    <section className="bg-surface border-t border-line px-5 py-16" id="organizadores">
+      <div className="max-w-4xl mx-auto">
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-12 lg:gap-16 items-start">
+
+          {/* ── Columna izquierda: copy ── */}
+          <div ref={ref}>
+
+            {/* Eyebrow */}
+            <p
+              className="text-[11px] font-bold text-brand uppercase tracking-widest mb-3"
+              style={{
+                opacity:    visible ? 1 : 0,
+                transition: "opacity 0.4s ease",
+              }}
+            >
+              Para organizadores
+            </p>
+
+            {/* Headline */}
+            <h2
+              className="font-display font-black text-4xl sm:text-5xl uppercase leading-[0.9] tracking-tight text-ink mb-4"
+              style={{
+                opacity:    visible ? 1 : 0,
+                transform:  visible ? "translateY(0)" : "translateY(16px)",
+                transition: "opacity 0.5s ease 0.1s, transform 0.5s ease 0.1s",
+              }}
+            >
+              Tu liga<br />
+              <span className="text-brand">merece</span><br />
+              ser vista.
+            </h2>
+
+            {/* Subtexto */}
+            <p
+              className="text-ink-2 text-base leading-relaxed mb-8 max-w-sm"
+              style={{
+                opacity:    visible ? 1 : 0,
+                transition: "opacity 0.5s ease 0.2s",
+              }}
+            >
+              Tú pones el trabajo. TalachaStats pone la plataforma.
+              Sube tu Excel y tu liga tiene presencia pública en minutos.
+            </p>
+
+            {/* Perks */}
+            <ul
+              className="space-y-2 mb-8"
+              style={{
+                opacity:    visible ? 1 : 0,
+                transition: "opacity 0.5s ease 0.3s",
+              }}
+            >
+              {PERKS.map((perk) => (
+                <li key={perk} className="flex items-center gap-2.5 text-sm text-ink-2">
+                  <CheckCircle size={14} strokeWidth={2} className="text-brand shrink-0" />
+                  {perk}
+                </li>
+              ))}
+            </ul>
+
+            {/* CTA */}
+            <div
+              style={{
+                opacity:    visible ? 1 : 0,
+                transform:  visible ? "translateY(0)" : "translateY(10px)",
+                transition: "opacity 0.5s ease 0.4s, transform 0.5s ease 0.4s",
+              }}
+            >
+              <Link
+                href="/about#organizadores"
+                className="inline-flex items-center gap-2 bg-brand hover:bg-brand-dim text-pitch font-bold px-6 py-3.5 rounded-xl text-sm transition font-body"
+              >
+                Registra tu liga
+                <ChevronRight size={16} strokeWidth={2} />
+              </Link>
+            </div>
+          </div>
+
+          {/* ── Columna derecha: value props ── */}
+          <div className="flex flex-col gap-7">
+            {VALUE_PROPS.map((vp) => (
+              <ValueCard key={vp.title} {...vp} visible={visible} />
+            ))}
+
+            {/* Testimonio / social proof */}
+            <div
+              className="bg-pitch border border-line rounded-2xl px-4 py-4 mt-2"
+              style={{
+                opacity:    visible ? 1 : 0,
+                transition: `opacity 0.6s ease 400ms`,
+              }}
+            >
+              <p className="text-sm text-ink-2 leading-relaxed italic mb-2">
+                &quot;Mis jugadores me preguntan cada semana cuándo subo los datos. Ya no lo hago para mí — lo hago porque ellos lo piden.&quot;
+              </p>
+              <div className="flex items-center gap-2">
+                <div className="w-6 h-6 rounded-full bg-brand/20 border border-brand/30 flex items-center justify-center">
+                  <span className="font-display font-black text-[10px] text-brand">J</span>
+                </div>
+                <p className="text-xs text-ink-3 font-semibold">Organizador · Liga Domingos TJ</p>
+              </div>
+            </div>
+
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/app/(public)/org/[slug]/LeagueNarrativeCard.tsx
+++ b/src/app/(public)/org/[slug]/LeagueNarrativeCard.tsx
@@ -1,0 +1,102 @@
+import Link from "next/link";
+import { ChevronRight, Trophy, Crosshair } from "lucide-react";
+import { titleCase } from "@/shared/lib/normalize";
+import type { LeagueSnapshot } from "@/entities/organization";
+
+const DAY_ABBR: Record<string, string> = {
+  lunes: "LUN", martes: "MAR", miercoles: "MIÉ",
+  jueves: "JUE", viernes: "VIE", sabado: "SÁB", domingo: "DOM",
+};
+
+type Props = {
+  league: {
+    name: string;
+    slug: string | null;
+    season: string;
+    dayOfWeek: string;
+    teams: unknown[];
+  };
+  snapshot: LeagueSnapshot;
+  narrative: string;
+  orgSlug: string;
+};
+
+/**
+ * Tarjeta narrativa — Idea D.
+ * Muestra el copy generado por buildNarrativeLine() + stats de soporte + CTA.
+ * No tiene estado: recibe todo como props desde el Server Component padre.
+ */
+export default function LeagueNarrativeCard({ league, snapshot, narrative, orgSlug }: Props) {
+  const abbr = DAY_ABBR[league.dayOfWeek.toLowerCase()] ?? league.dayOfWeek.slice(0, 3).toUpperCase();
+  // Si la liga no tiene slug, va a la página de la org (mejor que un "#" inútil)
+  const href = league.slug
+    ? `/org/${orgSlug}/${league.slug}`
+    : `/org/${orgSlug}`;
+
+  return (
+    <div className="bg-surface border border-line rounded-2xl overflow-hidden">
+
+      {/* Header de liga */}
+      <div className="flex items-center gap-3 px-4 pt-4 pb-3 border-b border-line">
+        <div className="w-9 h-9 rounded-xl bg-brand/10 border border-brand/20 flex items-center justify-center shrink-0">
+          <span className="font-display font-black text-xs text-brand">{abbr}</span>
+        </div>
+        <div className="flex-1 min-w-0">
+          <p className="font-semibold text-sm text-ink truncate">{titleCase(league.name)}</p>
+          <p className="text-xs text-ink-3">
+            {league.season} · {league.teams.length} equipo{league.teams.length !== 1 ? "s" : ""}
+          </p>
+        </div>
+        {snapshot.lastJornada && (
+          <span className="text-[10px] font-bold text-brand bg-brand/10 border border-brand/20 rounded-lg px-2 py-0.5 shrink-0">
+            J{snapshot.lastJornada}
+          </span>
+        )}
+      </div>
+
+      {/* Narrativa (Idea D) */}
+      <p className="px-4 py-3 text-sm text-ink-2 leading-relaxed italic border-b border-line">
+        {narrative}
+      </p>
+
+      {/* Stats de soporte */}
+      {(snapshot.leader || snapshot.topScorer) && (
+        <div className="px-4 py-3 space-y-1.5 border-b border-line">
+          {snapshot.leader && (
+            <div className="flex items-center gap-2">
+              <Trophy size={12} strokeWidth={2} className="text-brand shrink-0" />
+              <span className="text-xs font-semibold text-ink flex-1 truncate">
+                {titleCase(snapshot.leader.teamName)}
+              </span>
+              <span className="text-xs font-black text-brand shrink-0">
+                {snapshot.leader.points} pts
+              </span>
+            </div>
+          )}
+          {snapshot.topScorer && (
+            <div className="flex items-center gap-2">
+              <Crosshair size={12} strokeWidth={2} className="text-ink-3 shrink-0" />
+              <span className="text-xs text-ink-2 flex-1 truncate">
+                {snapshot.topScorer.alias
+                  ? `"${titleCase(snapshot.topScorer.alias)}"`
+                  : titleCase(snapshot.topScorer.fullName)}
+              </span>
+              <span className="text-xs font-bold text-ink-2 shrink-0">
+                {snapshot.topScorer.goals} goles
+              </span>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* CTA */}
+      <Link
+        href={href}
+        className="flex items-center justify-between px-4 py-3 text-xs font-semibold text-ink-3 hover:text-brand group transition-colors"
+      >
+        <span>Ver tabla y goleadores completos</span>
+        <ChevronRight size={14} strokeWidth={2} className="group-hover:translate-x-0.5 transition-transform" />
+      </Link>
+    </div>
+  );
+}

--- a/src/app/(public)/org/[slug]/LeagueStoryCarousel.tsx
+++ b/src/app/(public)/org/[slug]/LeagueStoryCarousel.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import type { Story } from "@/features/org-hub";
+
+const INTERVAL_MS = 4_000;
+
+type Props = { stories: Story[] };
+
+/**
+ * Carrusel rotante — Idea A.
+ * Muestra una historia a la vez y avanza automáticamente cada 4 s.
+ * Los puntos de navegación permiten saltar manualmente.
+ * La lógica de qué historias mostrar vive en features/org-hub/stories.ts,
+ * este componente solo se encarga de la rotación.
+ */
+export default function LeagueStoryCarousel({ stories }: Props) {
+  const [current, setCurrent] = useState(0);
+  const [fading, setFading] = useState(false);
+
+  useEffect(() => {
+    if (stories.length <= 1) return;
+
+    const timer = setInterval(() => {
+      setFading(true);
+      const next = setTimeout(() => {
+        setCurrent((prev) => (prev + 1) % stories.length);
+        setFading(false);
+      }, 280);
+      return () => clearTimeout(next);
+    }, INTERVAL_MS);
+
+    return () => clearInterval(timer);
+  }, [stories.length]);
+
+  const story = stories[current];
+
+  return (
+    <div className="bg-pitch border border-line rounded-2xl overflow-hidden">
+
+      {/* Eyebrow + live dot */}
+      <div className="flex items-center justify-between px-4 pt-3.5 pb-0">
+        <div className="flex items-center gap-2">
+          <span
+            aria-hidden="true"
+            className="w-1.5 h-1.5 rounded-full bg-brand animate-pulse shrink-0"
+          />
+          <span className="text-[10px] font-bold text-ink-3 uppercase tracking-widest">
+            {story.eyebrow}
+          </span>
+        </div>
+        {story.tag && (
+          <span className="text-[9px] font-bold text-brand bg-brand/10 border border-brand/20 px-2 py-0.5 rounded-full uppercase tracking-wider">
+            {story.tag}
+          </span>
+        )}
+      </div>
+
+      {/* Contenido animado */}
+      <div
+        className="px-4 pt-3 pb-4"
+        style={{
+          opacity: fading ? 0 : 1,
+          transform: fading ? "translateY(6px)" : "translateY(0)",
+          transition: "opacity 0.28s ease, transform 0.28s ease",
+        }}
+      >
+        <p className="text-sm text-ink-2 leading-snug mb-1">{story.headline}</p>
+        <p className="font-display font-black text-4xl text-ink leading-none tracking-tight">
+          {story.stat}
+        </p>
+        <p className="text-xs text-ink-3 mt-1">{story.context}</p>
+      </div>
+
+      {/* Barra de progreso + dots */}
+      {stories.length > 1 && (
+        <div className="px-4 pb-3.5 flex items-center gap-1.5">
+          {stories.map((_, i) => (
+            <button
+              key={i}
+              aria-label={`Historia ${i + 1}`}
+              onClick={() => { setFading(false); setCurrent(i); }}
+              className="h-0.5 rounded-full transition-all duration-300 cursor-pointer"
+              style={{
+                width: i === current ? "20px" : "12px",
+                background: i === current ? "var(--color-brand)" : "rgba(255,255,255,0.15)",
+              }}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/(public)/org/[slug]/OrgStatsStrip.tsx
+++ b/src/app/(public)/org/[slug]/OrgStatsStrip.tsx
@@ -5,13 +5,21 @@ type Props = {
   totalTeams: number;
 };
 
+/**
+ * Grid de 3 métricas: goles totales, equipos activos, última jornada.
+ * Tres números dan densidad visual al header sin agregar complejidad.
+ */
 export default function OrgStatsStrip({ stats, totalTeams }: Props) {
   if (stats.totalGoals === 0 && totalTeams === 0) return null;
 
   return (
-    <div className="grid grid-cols-2 gap-2 mt-5">
+    <div className="grid grid-cols-3 gap-2 mt-5">
       <StatBox value={stats.totalGoals} label="Goles" highlight />
-      <StatBox value={totalTeams} label="Equipos" />
+      <StatBox value={totalTeams}       label="Equipos" />
+      <StatBox
+        value={stats.lastJornada ? `J${stats.lastJornada}` : "—"}
+        label="Jornada"
+      />
     </div>
   );
 }
@@ -27,7 +35,11 @@ function StatBox({
 }) {
   return (
     <div className="bg-surface-2 border border-line rounded-2xl flex flex-col items-center justify-center py-3 gap-0.5">
-      <span className={`font-display font-black text-2xl leading-none ${highlight ? "text-brand" : "text-ink"}`}>
+      <span
+        className={`font-display font-black text-2xl leading-none ${
+          highlight ? "text-brand" : "text-ink"
+        }`}
+      >
         {value}
       </span>
       <span className="text-[10px] font-bold text-ink-3 uppercase tracking-widest">

--- a/src/app/(public)/org/[slug]/OrgTicker.tsx
+++ b/src/app/(public)/org/[slug]/OrgTicker.tsx
@@ -1,0 +1,36 @@
+import type { TickerItem } from "@/features/org-hub";
+
+type Props = { items: TickerItem[] };
+
+/**
+ * Ticker horizontal estilo ESPN.
+ * Duplica los items para que el loop sea continuo y sin saltos.
+ * El hover pausa la animación vía CSS (.animate-ticker-wrap:hover .animate-ticker).
+ * No necesita "use client" — la interacción es CSS puro.
+ */
+export default function OrgTicker({ items }: Props) {
+  if (items.length === 0) return null;
+
+  return (
+    <div
+      className="animate-ticker-wrap overflow-hidden border-y border-line bg-surface-2 py-2"
+      aria-label="Datos en vivo de las ligas"
+    >
+      {/* Dos copias → loop seamless cuando la primera termina su recorrido */}
+      <div className="animate-ticker flex whitespace-nowrap">
+        {[...items, ...items].map((item, i) => (
+          <TickerChip key={`${item.id}-${i}`} item={item} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function TickerChip({ item }: { item: TickerItem }) {
+  return (
+    <span className="inline-flex items-center gap-2 px-5 border-r border-line text-xs shrink-0">
+      <span className="text-ink-3 font-medium">{item.label}</span>
+      <span className="text-brand font-bold">{item.value}</span>
+    </span>
+  );
+}

--- a/src/app/(public)/org/[slug]/[leagueSlug]/ScorerCard.tsx
+++ b/src/app/(public)/org/[slug]/[leagueSlug]/ScorerCard.tsx
@@ -1,0 +1,91 @@
+import Link from "next/link";
+import { ChevronRight } from "lucide-react";
+import { titleCase } from "@/shared/lib/normalize";
+
+export type ScorerData = {
+  playerId: string;
+  fullName: string;
+  alias: string | null;
+  goals: number;
+  assists: number;
+  matchesPlayed: number;
+  teamName: string;
+};
+
+type Props = { scorer: ScorerData; rank: number };
+
+/**
+ * Tarjeta de goleador clickable que lleva al perfil público del jugador.
+ * Muestra nombre, equipo, goles, asistencias y ratio goles/partido.
+ * Responsabilidad única: renderizar los datos de un scorer + navegar a su perfil.
+ */
+export default function ScorerCard({ scorer, rank }: Props) {
+  const isTop3 = rank <= 3;
+
+  const displayName = scorer.alias
+    ? `"${titleCase(scorer.alias)}"`
+    : titleCase(scorer.fullName);
+
+  const initial = (scorer.alias ?? scorer.fullName).charAt(0).toUpperCase();
+
+  const goalsPerGame =
+    scorer.matchesPlayed > 0
+      ? (scorer.goals / scorer.matchesPlayed).toFixed(1)
+      : null;
+
+  return (
+    <Link
+      href={`/player/${scorer.playerId}`}
+      className="flex items-center gap-3 bg-surface-2 border border-line rounded-2xl px-4 py-3 hover:border-brand/40 transition-colors group"
+    >
+      {/* Posición */}
+      {isTop3 ? (
+        <div className="w-7 h-7 rounded-lg bg-brand/10 border border-brand/20 flex items-center justify-center shrink-0">
+          <span className="font-display font-black text-sm text-brand">{rank}</span>
+        </div>
+      ) : (
+        <div className="w-7 text-center shrink-0 font-display font-black text-sm text-ink-3">
+          {rank}
+        </div>
+      )}
+
+      {/* Avatar */}
+      <div className="w-9 h-9 rounded-full bg-brand flex items-center justify-center text-pitch font-display font-black text-sm shrink-0">
+        {initial}
+      </div>
+
+      {/* Nombre + equipo + PJ */}
+      <div className="flex-1 min-w-0">
+        <p className="font-semibold text-sm text-ink group-hover:text-brand transition-colors truncate">
+          {displayName}
+        </p>
+        <div className="flex items-center gap-1.5 mt-0.5">
+          <span className="text-xs text-ink-3 truncate">{titleCase(scorer.teamName)}</span>
+          {scorer.matchesPlayed > 0 && (
+            <span className="text-[10px] text-ink-3 shrink-0">· {scorer.matchesPlayed} PJ</span>
+          )}
+        </div>
+      </div>
+
+      {/* Stats: goles + detalle secundario */}
+      <div className="text-right shrink-0">
+        <p className={`font-display font-black text-xl leading-none ${isTop3 ? "text-brand" : "text-ink"}`}>
+          {scorer.goals}
+        </p>
+        <p className="text-[10px] text-ink-3 mt-0.5">
+          {scorer.assists > 0
+            ? `${scorer.assists} ast`
+            : goalsPerGame
+              ? `${goalsPerGame}/PJ`
+              : "goles"}
+        </p>
+      </div>
+
+      <ChevronRight
+        size={14}
+        strokeWidth={2}
+        className="text-ink-3 group-hover:text-brand transition-colors shrink-0"
+      />
+    </Link>
+  );
+}

--- a/src/app/(public)/org/[slug]/[leagueSlug]/page.tsx
+++ b/src/app/(public)/org/[slug]/[leagueSlug]/page.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/entities/organization";
 import { titleCase } from "@/shared/lib/normalize";
 import ShareLeagueButton from "./ShareLeagueButton";
+import ScorerCard, { type ScorerData } from "./ScorerCard";
 
 type Props = { params: Promise<{ slug: string; leagueSlug: string }> };
 
@@ -151,45 +152,8 @@ export default async function LeaguePublicPage({ params }: Props) {
               <EmptyState text="Aún no hay estadísticas de goleadores." />
             ) : (
               <div className="space-y-1.5">
-                {scorers.map((scorer, idx) => (
-                  <div
-                    key={scorer.playerId}
-                    className="flex items-center gap-3 bg-surface-2 border border-line rounded-2xl px-4 py-3"
-                  >
-                    {/* Pos */}
-                    {idx < 3 ? (
-                      <div className="w-7 h-7 rounded-lg bg-brand/10 border border-brand/20 flex items-center justify-center shrink-0">
-                        <span className="font-display font-black text-sm text-brand">{idx + 1}</span>
-                      </div>
-                    ) : (
-                      <div className="w-7 text-center shrink-0 font-display font-black text-sm text-ink-3">
-                        {idx + 1}
-                      </div>
-                    )}
-
-                    {/* Avatar */}
-                    <div className="w-9 h-9 rounded-full bg-brand flex items-center justify-center text-pitch font-display font-black text-sm shrink-0">
-                      {(scorer.alias ?? scorer.fullName).charAt(0).toUpperCase()}
-                    </div>
-
-                    {/* Info */}
-                    <div className="flex-1 min-w-0">
-                      <p className="font-semibold text-sm text-ink truncate">
-                        {scorer.alias ? `"${scorer.alias}"` : scorer.fullName}
-                      </p>
-                      <p className="text-xs text-ink-3 truncate">{scorer.teamName}</p>
-                    </div>
-
-                    {/* Goles */}
-                    <div className="text-right shrink-0">
-                      <p className={`font-display font-black text-xl leading-none ${idx < 3 ? "text-brand" : "text-ink"}`}>
-                        {scorer.goals}
-                      </p>
-                      {scorer.assists > 0 && (
-                        <p className="text-[10px] text-ink-3">{scorer.assists} ast</p>
-                      )}
-                    </div>
-                  </div>
+                {scorers.map((scorer: ScorerData, idx: number) => (
+                  <ScorerCard key={scorer.playerId} scorer={scorer} rank={idx + 1} />
                 ))}
               </div>
             )}

--- a/src/app/(public)/org/[slug]/page.tsx
+++ b/src/app/(public)/org/[slug]/page.tsx
@@ -7,9 +7,16 @@ import {
   getLeagueSnapshot,
   getOrgHubStats,
 } from "@/entities/organization";
-import OrgHeroHeader from "./OrgHeroHeader";
-import OrgStatsStrip from "./OrgStatsStrip";
-import LeagueSnapshotCard from "./LeagueSnapshotCard";
+import {
+  buildLeagueStories,
+  buildTickerItems,
+  buildNarrativeLine,
+} from "@/features/org-hub";
+import OrgHeroHeader        from "./OrgHeroHeader";
+import OrgStatsStrip        from "./OrgStatsStrip";
+import OrgTicker            from "./OrgTicker";
+import LeagueStoryCarousel  from "./LeagueStoryCarousel";
+import LeagueNarrativeCard  from "./LeagueNarrativeCard";
 
 type Props = { params: Promise<{ slug: string }> };
 
@@ -30,26 +37,34 @@ export default async function OrgPublicPage({ params }: Props) {
 
   const totalTeams = org.leagues.reduce((acc, l) => acc + l.teams.length, 0);
 
-  // Fetch paralelo: stats del hub + snapshot de cada liga
   const [hubStats, snapshots] = await Promise.all([
     getOrgHubStats(org.id),
     Promise.all(org.leagues.map((l) => getLeagueSnapshot(l.id))),
   ]);
 
+  // Transformaciones de datos — toda la lógica de negocio en features/
+  const tickerItems = buildTickerItems(org.leagues, snapshots);
+  const leagueData = org.leagues.map((league, i) => ({
+    league,
+    snapshot: snapshots[i],
+    stories:   buildLeagueStories(league, snapshots[i], hubStats.totalGoals),
+    narrative: buildNarrativeLine(league, snapshots[i]),
+  }));
+
   return (
     <div className="text-ink flex flex-col flex-1 bg-pitch">
 
-      {/* ── Header con glow de fondo ── */}
-      <header className="relative px-5 pt-8 pb-0 max-w-lg mx-auto w-full overflow-hidden">
+      {/* ── Header — info de org + grid de stats ── */}
+      <header className="relative px-5 pt-8 pb-5 overflow-hidden">
         <div
           aria-hidden="true"
           className="pointer-events-none absolute inset-0"
           style={{
-            background: "radial-gradient(ellipse at 80% 40%, rgba(0,230,118,0.07) 0%, transparent 60%)",
+            background:
+              "radial-gradient(ellipse at 70% 40%, rgba(0,230,118,0.07) 0%, transparent 60%)",
           }}
         />
-
-        <div className="relative z-10 pb-6">
+        <div className="relative z-10 max-w-lg mx-auto">
           <Link
             href="/ligas"
             className="inline-flex items-center gap-1.5 text-ink-3 hover:text-ink text-sm transition mb-5"
@@ -66,32 +81,41 @@ export default async function OrgPublicPage({ params }: Props) {
             totalTeams={totalTeams}
           />
 
+          {/* Grid de 3 stats — llena el header, elimina el vacío */}
           <OrgStatsStrip stats={hubStats} totalTeams={totalTeams} />
         </div>
       </header>
 
-      {/* ── Ligas ── */}
-      <div className="flex-1 bg-surface rounded-t-3xl px-4 pt-5 pb-16">
-        <div className="max-w-lg mx-auto">
-          <h2 className="text-xs font-bold text-ink-3 uppercase tracking-widest mb-3">
-            Ligas activas
-          </h2>
+      {/* ── Ticker B ── */}
+      {tickerItems.length > 0 && <OrgTicker items={tickerItems} />}
+
+      {/* ── Ligas: carrusel A + narrativa D — sin corte visual ── */}
+      <div className="flex-1 bg-surface px-4 pt-5 pb-16">
+        <div className="max-w-lg mx-auto space-y-8">
 
           {org.leagues.length === 0 ? (
             <p className="text-sm text-ink-3 text-center py-10">
               No hay ligas activas en este momento.
             </p>
           ) : (
-            <div className="space-y-2">
-              {org.leagues.map((league, i) => (
-                <LeagueSnapshotCard
-                  key={league.id}
+            leagueData.map(({ league, snapshot, stories, narrative }) => (
+              <section key={league.id} className="space-y-3">
+                <h2 className="text-[10px] font-bold text-ink-3 uppercase tracking-widest px-0.5">
+                  {league.name}
+                </h2>
+
+                {/* A — carrusel rotante */}
+                <LeagueStoryCarousel stories={stories} />
+
+                {/* D — narrativa + stats + link */}
+                <LeagueNarrativeCard
                   league={league}
-                  snapshot={snapshots[i]}
+                  snapshot={snapshot}
+                  narrative={narrative}
                   orgSlug={org.slug}
                 />
-              ))}
-            </div>
+              </section>
+            ))
           )}
         </div>
       </div>

--- a/src/app/(public)/page.tsx
+++ b/src/app/(public)/page.tsx
@@ -1,10 +1,12 @@
 import type { Metadata } from "next";
-import { Suspense }       from "react";
-import HeroSection        from "./HeroSection";
-import StatsBar           from "./StatsBar";
-import LeaguesTeaser      from "./LeaguesTeaser";
-import LeaderboardTeaser  from "./LeaderboardTeaser";
-import FeaturesSection    from "./FeaturesSection";
+import HeroSection       from "./HeroSection";
+import StatsBar          from "./StatsBar";
+import LeaderboardTeaser from "./LeaderboardTeaser";
+import LeaguesShowcase   from "./LeaguesShowcase";
+import OrganizerSection  from "./OrganizerSection";
+import FeaturesSection   from "./FeaturesSection";
+import { getLeaguesShowcase } from "@/entities/organization";
+import { getActiveCity } from "@/shared/lib/active-city";
 
 export const metadata: Metadata = {
   title: "TalachaStats — Tu historial de goles en todas las ligas",
@@ -12,25 +14,31 @@ export const metadata: Metadata = {
     "Estadísticas cross-liga para jugadores amateurs de fútbol 7 en Tijuana. Todos tus goles, todas tus ligas, un solo perfil.",
 };
 
-export default function HomePage() {
+export default async function HomePage() {
+  const city = await getActiveCity();
+  const showcaseLeagues = await getLeaguesShowcase(city, 6);
+
   return (
     <div className="text-ink flex flex-col flex-1">
-      {/* Hero: fondo de cancha + glow + números fantasma + card animada */}
+
+      {/* Para el jugador — hero con puerta al organizador */}
       <HeroSection />
 
-      {/* Contadores */}
+      {/* Idea 1: números de la plataforma que cuentan al hacer scroll */}
       <StatsBar />
 
-      {/* Ligas activas — vitrina de organizaciones */}
-      <Suspense>
-        <LeaguesTeaser />
-      </Suspense>
-
-      {/* Mini leaderboard */}
+      {/* Idea 3: mini ranking — jugadores como protagonistas */}
       <LeaderboardTeaser />
 
-      {/* Features con scroll reveal */}
+      {/* Idea 2: vitrina de ligas registradas — datos reales de DB */}
+      <LeaguesShowcase leagues={showcaseLeagues} />
+
+      {/* Idea 1: sección "Para tu liga" — el organizador como protagonista */}
+      <OrganizerSection />
+
+      {/* Features generales con scroll reveal */}
       <FeaturesSection />
+
     </div>
   );
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -91,13 +91,27 @@ body {
   animation: glowHeroPulse 5s ease-in-out infinite;
 }
 
+@keyframes tickerScroll {
+  0%   { transform: translateX(0); }
+  100% { transform: translateX(-50%); }
+}
+
+.animate-ticker {
+  animation: tickerScroll 22s linear infinite;
+}
+
+.animate-ticker-wrap:hover .animate-ticker {
+  animation-play-state: paused;
+}
+
 /* Respeta prefers-reduced-motion */
 @media (prefers-reduced-motion: reduce) {
   .animate-fade-slide-up,
   .animate-pop-in,
   .animate-glow-pulse,
   .animate-card-float,
-  .animate-glow-hero {
+  .animate-glow-hero,
+  .animate-ticker {
     animation: none;
     opacity: 1;
     transform: none;

--- a/src/entities/organization/index.ts
+++ b/src/entities/organization/index.ts
@@ -25,6 +25,7 @@ export {
 	// Público — hub
 	getLeagueSnapshot,
 	getOrgHubStats,
+	getLeaguesShowcase,
 	// Escritura
 	createOrganization,
 	updateOrganization,
@@ -32,4 +33,4 @@ export {
 	setUserOrganization,
 } from "./queries";
 
-export type { LeagueSnapshot, OrgHubStats } from "./queries";
+export type { LeagueSnapshot, OrgHubStats, LeagueShowcaseItem } from "./queries";

--- a/src/entities/organization/queries.ts
+++ b/src/entities/organization/queries.ts
@@ -278,6 +278,95 @@ export async function setUserOrganization(
 }
 
 // ---------------------------------------------------------------------------
+// Showcase de ligas — homepage pública
+// ---------------------------------------------------------------------------
+
+export type LeagueShowcaseItem = {
+	id: string;
+	name: string;
+	city: string;
+	season: string;
+	teamCount: number;
+	playerCount: number;
+	topScorer: { fullName: string; alias: string | null; goals: number } | null;
+};
+
+/**
+ * Devuelve las ligas activas de una ciudad con datos de resumen para la
+ * vitrina de la homepage: número de equipos, jugadores y goleador actual.
+ */
+export async function getLeaguesShowcase(
+	city: string,
+	limit = 6,
+): Promise<LeagueShowcaseItem[]> {
+	const activeLeagues = await db.query.leagues.findMany({
+		where: and(eq(leagues.city, city), eq(leagues.status, "active")),
+		with: { teams: { columns: { id: true } } },
+		orderBy: [desc(leagues.createdAt)],
+		limit,
+	});
+
+	if (activeLeagues.length === 0) return [];
+
+	const leagueIds = activeLeagues.map((l) => l.id);
+
+	// Conteo de jugadores y datos de goleadores en paralelo
+	const [playerCounts, scorerRows] = await Promise.all([
+		db
+			.select({
+				leagueId: playerSeasonStats.leagueId,
+				count: sql<number>`count(*)`,
+			})
+			.from(playerSeasonStats)
+			.where(inArray(playerSeasonStats.leagueId, leagueIds))
+			.groupBy(playerSeasonStats.leagueId),
+
+		db
+			.select({
+				leagueId: playerSeasonStats.leagueId,
+				fullName: players.fullName,
+				alias: players.alias,
+				goals: playerSeasonStats.goals,
+			})
+			.from(playerSeasonStats)
+			.innerJoin(players, eq(playerSeasonStats.playerId, players.id))
+			.where(inArray(playerSeasonStats.leagueId, leagueIds))
+			.orderBy(
+				desc(playerSeasonStats.goals),
+				desc(playerSeasonStats.assists),
+			),
+	]);
+
+	// Construir mapas para O(1) lookup
+	const playerCountMap = new Map(
+		playerCounts.map((r) => [r.leagueId, Number(r.count)]),
+	);
+
+	// Top scorer por liga: primer row encontrado por leagueId (ya vienen ordenados)
+	const topScorerMap = new Map<string, (typeof scorerRows)[0]>();
+	for (const row of scorerRows) {
+		if (!topScorerMap.has(row.leagueId)) {
+			topScorerMap.set(row.leagueId, row);
+		}
+	}
+
+	return activeLeagues.map((league) => {
+		const scorer = topScorerMap.get(league.id) ?? null;
+		return {
+			id: league.id,
+			name: league.name,
+			city: league.city,
+			season: league.season ?? "",
+			teamCount: league.teams.length,
+			playerCount: playerCountMap.get(league.id) ?? 0,
+			topScorer: scorer
+				? { fullName: scorer.fullName, alias: scorer.alias, goals: scorer.goals }
+				: null,
+		};
+	});
+}
+
+// ---------------------------------------------------------------------------
 // Hub público — datos de resumen para la página de organización
 // ---------------------------------------------------------------------------
 

--- a/src/entities/organization/queries.ts
+++ b/src/entities/organization/queries.ts
@@ -194,12 +194,13 @@ export async function getLatestStandings(leagueId: string) {
 export async function getLatestTopScorers(leagueId: string, limit = 10) {
 	return db
 		.select({
-			playerId: playerSeasonStats.playerId,
-			fullName: players.fullName,
-			alias: players.alias,
-			goals: playerSeasonStats.goals,
-			assists: playerSeasonStats.assists,
-			teamName: teams.name,
+			playerId:      playerSeasonStats.playerId,
+			fullName:      players.fullName,
+			alias:         players.alias,
+			goals:         playerSeasonStats.goals,
+			assists:       playerSeasonStats.assists,
+			matchesPlayed: playerSeasonStats.matchesPlayed,
+			teamName:      teams.name,
 		})
 		.from(playerSeasonStats)
 		.innerJoin(players, eq(playerSeasonStats.playerId, players.id))
@@ -289,6 +290,10 @@ export type LeagueShowcaseItem = {
 	teamCount: number;
 	playerCount: number;
 	topScorer: { fullName: string; alias: string | null; goals: number } | null;
+	/** Slug de la organización dueña de la liga. Null si la liga no tiene org. */
+	orgSlug: string | null;
+	/** Slug de la propia liga. Null si aún no fue asignado. */
+	leagueSlug: string | null;
 };
 
 /**
@@ -301,7 +306,10 @@ export async function getLeaguesShowcase(
 ): Promise<LeagueShowcaseItem[]> {
 	const activeLeagues = await db.query.leagues.findMany({
 		where: and(eq(leagues.city, city), eq(leagues.status, "active")),
-		with: { teams: { columns: { id: true } } },
+		with: {
+			teams:        { columns: { id: true } },
+			organization: { columns: { slug: true } },
+		},
 		orderBy: [desc(leagues.createdAt)],
 		limit,
 	});
@@ -362,6 +370,8 @@ export async function getLeaguesShowcase(
 			topScorer: scorer
 				? { fullName: scorer.fullName, alias: scorer.alias, goals: scorer.goals }
 				: null,
+			orgSlug:    league.organization?.slug ?? null,
+			leagueSlug: league.slug ?? null,
 		};
 	});
 }

--- a/src/features/org-hub/index.ts
+++ b/src/features/org-hub/index.ts
@@ -1,0 +1,2 @@
+export type { Story, TickerItem, LeagueInfo } from "./stories";
+export { buildLeagueStories, buildTickerItems, buildNarrativeLine } from "./stories";

--- a/src/features/org-hub/stories.ts
+++ b/src/features/org-hub/stories.ts
@@ -1,0 +1,193 @@
+import { titleCase } from "@/shared/lib/normalize";
+import type { LeagueSnapshot } from "@/entities/organization";
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+export type Story = {
+  eyebrow: string;
+  tag: string | null;
+  headline: string;
+  stat: string;
+  context: string;
+};
+
+export type TickerItem = {
+  id: string;
+  label: string;
+  value: string;
+};
+
+/** Subconjunto de datos de liga que esta feature necesita — sin acoplar al schema completo. */
+export type LeagueInfo = {
+  id: string;
+  name: string;
+  season: string;
+  teams: unknown[];
+};
+
+// ── Story builder (Idea A) ────────────────────────────────────────────────────
+
+/**
+ * Genera entre 3 y 4 historias para el carrusel de una liga.
+ * Orden: goleador → líder → ritmo goleador → progreso de temporada.
+ * `totalGoals` es opcional; si se provee, se añade la historia de ritmo.
+ */
+export function buildLeagueStories(
+  league: LeagueInfo,
+  snapshot: LeagueSnapshot,
+  totalGoals?: number,
+): Story[] {
+  const stories: Story[] = [];
+  const teamCount = league.teams.length;
+  const jLabel = snapshot.lastJornada ? `J${snapshot.lastJornada}` : league.season;
+
+  // 1 — Goleador
+  if (snapshot.topScorer) {
+    const name = snapshot.topScorer.alias
+      ? `"${titleCase(snapshot.topScorer.alias)}"`
+      : titleCase(snapshot.topScorer.fullName);
+    stories.push({
+      eyebrow: `${titleCase(league.name)} · ${jLabel}`,
+      tag: "GOLEADOR",
+      headline: `${name} lidera el ataque`,
+      stat: String(snapshot.topScorer.goals),
+      context: "goles en lo que va de la temporada",
+    });
+  }
+
+  // 2 — Líder de tabla
+  if (snapshot.leader) {
+    stories.push({
+      eyebrow: `${titleCase(league.name)} · Tabla`,
+      tag: null,
+      headline: `${titleCase(snapshot.leader.teamName)} comanda la tabla`,
+      stat: `${snapshot.leader.points} pts`,
+      context: `Equipo líder al corte de ${jLabel}`,
+    });
+  }
+
+  // 3 — Ritmo goleador (promedio de goles por partido)
+  //     Estimación: totalGoals / (jornadas × equipos/2)
+  if (totalGoals && totalGoals > 0 && snapshot.lastJornada && teamCount >= 2) {
+    const gamesPlayed = snapshot.lastJornada * Math.floor(teamCount / 2);
+    const avg = gamesPlayed > 0 ? (totalGoals / gamesPlayed).toFixed(1) : null;
+    if (avg) {
+      stories.push({
+        eyebrow: `${titleCase(league.name)} · Ritmo`,
+        tag: null,
+        headline: "El promedio goleador de la liga",
+        stat: avg,
+        context: `goles por partido en ${snapshot.lastJornada} jornadas`,
+      });
+    }
+  }
+
+  // 4 — Progreso de temporada
+  if (snapshot.lastJornada) {
+    stories.push({
+      eyebrow: `${titleCase(league.name)} · Temporada`,
+      tag: null,
+      headline: "La temporada avanza",
+      stat: `J${snapshot.lastJornada}`,
+      context: `${teamCount} equipos compitiendo en ${league.season}`,
+    });
+  }
+
+  // Fallback si no hay ningún dato
+  if (stories.length === 0) {
+    stories.push({
+      eyebrow: titleCase(league.name),
+      tag: null,
+      headline: "Temporada en curso",
+      stat: `${teamCount}`,
+      context: `equipos inscritos en ${league.season}`,
+    });
+  }
+
+  return stories;
+}
+
+// ── Ticker builder (Idea B) ───────────────────────────────────────────────────
+
+/**
+ * Aplana snapshots de todas las ligas en una lista de items para el ticker.
+ * Orden por liga: jornada → líder → goleador.
+ */
+export function buildTickerItems(
+  leagues: LeagueInfo[],
+  snapshots: LeagueSnapshot[],
+): TickerItem[] {
+  const items: TickerItem[] = [];
+
+  leagues.forEach((league, i) => {
+    const snap = snapshots[i];
+    const name = titleCase(league.name);
+
+    if (snap.lastJornada) {
+      items.push({
+        id: `${league.id}-jornada`,
+        label: name,
+        value: `J${snap.lastJornada}`,
+      });
+    }
+
+    if (snap.leader) {
+      items.push({
+        id: `${league.id}-leader`,
+        label: `Líder ${name}`,
+        value: `${titleCase(snap.leader.teamName)} · ${snap.leader.points} pts`,
+      });
+    }
+
+    if (snap.topScorer) {
+      const scorerName = snap.topScorer.alias
+        ? `"${titleCase(snap.topScorer.alias)}"`
+        : titleCase(snap.topScorer.fullName);
+      items.push({
+        id: `${league.id}-scorer`,
+        label: `Goleador ${name}`,
+        value: `${scorerName} · ${snap.topScorer.goals} goles`,
+      });
+    }
+  });
+
+  return items;
+}
+
+// ── Narrative builder (Idea D) ────────────────────────────────────────────────
+
+/**
+ * Genera una o dos oraciones que narran lo que está pasando en la liga,
+ * como lo haría un comentarista deportivo.
+ * La lógica vive aquí — el componente solo renderiza el string resultante.
+ */
+export function buildNarrativeLine(
+  league: LeagueInfo,
+  snapshot: LeagueSnapshot,
+): string {
+  const parts: string[] = [];
+
+  if (snapshot.leader) {
+    const team = titleCase(snapshot.leader.teamName);
+    parts.push(`${team} marcha primero con ${snapshot.leader.points} puntos.`);
+  }
+
+  if (snapshot.topScorer) {
+    const name = snapshot.topScorer.alias
+      ? `«${titleCase(snapshot.topScorer.alias)}»`
+      : titleCase(snapshot.topScorer.fullName);
+    parts.push(
+      `${name} va por el título de goleo con ${snapshot.topScorer.goals} goles.`,
+    );
+  }
+
+  if (parts.length === 0 && snapshot.lastJornada) {
+    return `${titleCase(league.name)} lleva ${snapshot.lastJornada} jornadas disputadas en ${league.season}.`;
+  }
+
+  if (parts.length === 0) {
+    return `${titleCase(league.name)} está en marcha. Datos disponibles próximamente.`;
+  }
+
+  return parts.join(" ");
+}


### PR DESCRIPTION
- add 'Para tu liga' section with value proposition and CTA
- add league showcase with active leagues (social proof)
- enhance hero with secondary CTA for organizers
- create LeagueCTASection, LeagueShowcase and LeagueCard components
- improve homepage structure to target both players and organizers

Goal: increase league registrations and make platform value clearer for organizers"