### PR TITLE
feat(schema): registro publico — verificacion de email y estado trial…

### DIFF
--- a/ROADMAP_REGISTRO_PUBLICO.md
+++ b/ROADMAP_REGISTRO_PUBLICO.md
@@ -1,0 +1,601 @@
+# Roadmap: Registro Público de Organizadores
+
+> Objetivo: Abrir TalachaStats al público. Cualquier persona puede registrarse como organizador,
+> crear su organización y subir su liga. Los datos quedan en modo **trial** hasta que nosotros
+> los verificamos manualmente. Solo las ligas verificadas aparecen en vistas cross-org.
+
+---
+
+## Estado actual del codebase (referencia)
+
+| Qué existe                                             | Estado       |
+| ------------------------------------------------------ | ------------ |
+| `POST /api/auth/login` + página `/login`               | ✅ Funciona  |
+| `users` table con email + passwordHash + role + active | ✅ Existe    |
+| `organizations` table con name + slug + city           | ✅ Existe    |
+| `users.email_verified`                                 | ❌ Falta     |
+| `organizations.status` (trial/verified)                | ❌ Falta     |
+| Registro público                                       | ❌ No existe |
+| Onboarding (crear org al registrarse)                  | ❌ No existe |
+| Middleware root de autenticación                       | ❌ No existe |
+
+---
+
+## Epics y orden de ejecución
+
+```
+Epic A: Schema          →  Epic B: Email service
+                               ↓
+                        Epic C: Registro público
+                               ↓
+                        Epic D: Onboarding forzado
+                               ↓
+                        Epic E: Sistema Trial/Verified
+                               ↓
+                        Epic F: Admin — Verificaciones
+```
+
+---
+
+## Epic A — Schema y migraciones
+
+### A1 · Migración: campos de verificación de email en `users`
+
+**Labels:** `schema`, `migration`, `backend`
+**Bloquea:** C1, C2, C5
+
+**Qué hacer:**
+
+Agregar a la tabla `users`:
+
+```sql
+email_verified          boolean   NOT NULL DEFAULT false
+email_verification_token text     NULLABLE UNIQUE
+email_verification_expires_at timestamp with timezone  NULLABLE
+```
+
+Y en `schema.ts`:
+
+```ts
+emailVerified: boolean("email_verified").notNull().default(false),
+emailVerificationToken: text("email_verification_token").unique(),
+emailVerificationExpiresAt: timestamp("email_verification_expires_at", { withTimezone: true }),
+```
+
+**Criterios de aceptación:**
+
+- [ ] Migración de Drizzle generada y aplicada en dev
+- [ ] Schema.ts actualizado
+- [ ] Los usuarios existentes quedan con `email_verified = true` (son cuentas ya validadas manualmente)
+
+---
+
+### A2 · Migración: `status` en `organizations`
+
+**Labels:** `schema`, `migration`, `backend`
+**Bloquea:** E1, E2, E3, F2, F3
+
+**Qué hacer:**
+
+Agregar a la tabla `organizations`:
+
+```sql
+status                    text  NOT NULL DEFAULT 'trial'   -- 'trial' | 'verified'
+verification_requested_at timestamp with timezone  NULLABLE
+```
+
+Y en `schema.ts`:
+
+```ts
+status: text("status").notNull().default("trial"), // "trial" | "verified"
+verificationRequestedAt: timestamp("verification_requested_at", { withTimezone: true }),
+```
+
+**Criterios de aceptación:**
+
+- [ ] Migración aplicada
+- [ ] Las organizaciones existentes (nuestras ligas piloto) quedan con `status = 'verified'`
+- [ ] Schema.ts actualizado
+
+---
+
+## Epic B — Servicio de email
+
+### B1 · Configurar proveedor de email (Resend)
+
+**Labels:** `infra`, `email`, `backend`
+**Bloquea:** C1
+
+**Qué hacer:**
+
+Instalar Resend (`npm install resend`), configurar variable `RESEND_API_KEY` en `.env`.
+
+Crear `shared/lib/email.ts` con función base:
+
+```ts
+export async function sendEmail(to: string, subject: string, html: string): Promise<void>;
+```
+
+**Criterios de aceptación:**
+
+- [ ] `RESEND_API_KEY` en `.env.example` documentado
+- [ ] `shared/lib/email.ts` creado y funcionando
+- [ ] Email de prueba llega a bandeja de entrada (no spam)
+
+---
+
+### B2 · Template de email de verificación
+
+**Labels:** `email`, `backend`
+**Depende de:** B1
+**Bloquea:** C1
+
+**Qué hacer:**
+
+Crear `shared/lib/email-templates.ts` con función:
+
+```ts
+export function verificationEmailHtml(params: { name: string; verificationUrl: string }): string;
+```
+
+Email simple, en español, con el link de verificación. Sin librerías de templates — HTML inline limpio.
+
+**Criterios de aceptación:**
+
+- [ ] Template renderiza correctamente en Gmail y en cliente móvil
+- [ ] El link de verificación es visible y clicable
+- [ ] Menciona que el link expira en 24 horas
+
+---
+
+## Epic C — Registro público
+
+### C1 · Endpoint `POST /api/auth/register`
+
+**Labels:** `backend`, `auth`
+**Depende de:** A1, B2
+**Bloquea:** C3
+
+**Qué hacer:**
+
+Crear `app/api/auth/register/route.ts`. Flujo:
+
+1. Validar body con Zod: `{ name, email, password }`
+2. Verificar que el email no esté registrado
+3. Crear usuario con `emailVerified = false`
+4. Generar token de verificación (random UUID o crypto.randomBytes)
+5. Guardar token + expiración (24h) en el usuario
+6. Enviar email de verificación
+7. Retornar `apiSuccess({ message: "Revisa tu correo" })`
+
+Schema Zod en `entities/user/model.ts`:
+
+```ts
+export const RegisterSchema = z.object({
+	name: z.string().min(2).max(80),
+	email: z.string().email().toLowerCase(),
+	password: z.string().min(8, "Mínimo 8 caracteres"),
+});
+```
+
+**Criterios de aceptación:**
+
+- [ ] Email duplicado retorna `apiError("Este correo ya está registrado", 409)`
+- [ ] Usuario creado con `emailVerified = false`, `role = 'organizer'`, `organizationId = null`
+- [ ] Email de verificación llega correctamente
+- [ ] Token expira a las 24 horas
+- [ ] Contraseña hasheada correctamente (usa `hashPassword` existente)
+
+---
+
+### C2 · Endpoint `GET /api/auth/verify-email?token=xxx`
+
+**Labels:** `backend`, `auth`
+**Depende de:** A1
+**Bloquea:** C4
+
+**Qué hacer:**
+
+Crear `app/api/auth/verify-email/route.ts`. Flujo:
+
+1. Leer `token` del query string
+2. Buscar usuario con ese token
+3. Verificar que no haya expirado
+4. Marcar `emailVerified = true`, limpiar token y expiración
+5. Crear sesión (como en login) y redirigir a `/onboarding`
+
+**Criterios de aceptación:**
+
+- [ ] Token válido → sesión creada + redirect a `/onboarding`
+- [ ] Token inválido → redirect a `/registro?error=token-invalido`
+- [ ] Token expirado → redirect a `/registro?error=token-expirado`
+- [ ] Token usado dos veces → error (ya no existe en DB)
+
+---
+
+### C3 · Página `/registro`
+
+**Labels:** `frontend`, `auth`
+**Depende de:** C1
+
+**Qué hacer:**
+
+Crear `app/registro/page.tsx` (Client Component). Formulario con:
+
+- Nombre completo
+- Correo electrónico
+- Contraseña (mínimo 8 caracteres)
+- Botón "Crear cuenta"
+
+Después de submit exitoso, redirigir a `/verificar-email`.
+
+Misma estética que `/login` (dark, verde, centrado).
+
+Agregar link "¿Ya tienes cuenta? Inicia sesión" apuntando a `/login`.
+
+**Criterios de aceptación:**
+
+- [ ] Validación client-side antes de enviar (feedback inmediato)
+- [ ] Errores de la API se muestran en la UI
+- [ ] Link "Ya tienes cuenta" visible y funcional
+- [ ] Responsive en móvil
+
+---
+
+### C4 · Página `/verificar-email`
+
+**Labels:** `frontend`, `auth`
+**Depende de:** C2
+
+**Qué hacer:**
+
+Crear `app/verificar-email/page.tsx`. Pantalla estática que dice:
+
+> "Revisa tu correo"
+> Te enviamos un link de verificación a [email]. Haz clic en el link para activar tu cuenta.
+> El link expira en 24 horas.
+
+Opcionalmente: botón "Reenviar correo" (puede ser un segundo endpoint o quedar para después).
+
+**Criterios de aceptación:**
+
+- [ ] Muestra el email al que se envió (pasado como query param desde `/registro`)
+- [ ] No tiene estado interactivo complejo — es pantalla informativa
+
+---
+
+### C5 · Bloquear login si email no verificado
+
+**Labels:** `backend`, `auth`
+**Depende de:** A1
+
+**Qué hacer:**
+
+Modificar `app/api/auth/login/route.ts`. Después de verificar la contraseña, agregar:
+
+```ts
+if (!user.emailVerified) {
+	return apiError("Verifica tu correo antes de iniciar sesión", 403);
+}
+```
+
+Mostrar el error en la página de login con instrucción de revisar el correo.
+
+**Criterios de aceptación:**
+
+- [ ] Usuario no verificado no puede loguear
+- [ ] Error en login muestra mensaje claro (no genérico "credenciales incorrectas")
+
+---
+
+## Epic D — Onboarding forzado
+
+### D1 · Middleware root: redirigir a `/onboarding` si no tiene org
+
+**Labels:** `backend`, `auth`, `middleware`
+**Depende de:** A1
+**Bloquea:** D3
+
+**Qué hacer:**
+
+Crear `src/middleware.ts` (Next.js middleware). Lógica:
+
+```
+Ruta /admin/** + sesión válida + user.organizationId === null
+  → redirect /onboarding
+
+Ruta /admin/** + sin sesión
+  → redirect /login?from=[ruta original]
+
+Ruta /onboarding + sin sesión
+  → redirect /login
+```
+
+El middleware corre en el Edge Runtime — solo verificar el token de sesión (no consultar DB).
+Guardar `organizationId` en el token de sesión para evitar consultas en el edge.
+
+> **Nota:** Esto requiere re-emitir la cookie de sesión después del onboarding con el `organizationId` incluido, o usar un mecanismo alternativo (e.g. el layout de admin ya consulta el user completo).
+
+**Criterios de aceptación:**
+
+- [ ] Organizer sin org no puede acceder a `/admin`
+- [ ] Acceso a `/admin` sin sesión redirige a login con `from` param
+- [ ] Owner (`role = 'owner'`) no es redirigido a onboarding (no necesita org)
+
+---
+
+### D2 · Endpoint `POST /api/organizations`
+
+**Labels:** `backend`
+**Depende de:** A2
+**Bloquea:** D3
+
+**Qué hacer:**
+
+Crear `app/api/organizations/route.ts`. Flujo:
+
+1. Verificar sesión
+2. Verificar que el user aún no tiene org
+3. Validar body: `{ name, city }`
+4. Generar slug único a partir del nombre
+5. Crear organización con `status = 'trial'`
+6. Actualizar `users.organizationId` con el nuevo ID
+7. Retornar la org creada
+
+Schema Zod en `entities/organization/model.ts` (crear si no existe):
+
+```ts
+export const CreateOrganizationSchema = z.object({
+	name: z.string().min(2).max(100),
+	city: z.string().min(2).max(80),
+});
+```
+
+**Criterios de aceptación:**
+
+- [ ] Slug generado automáticamente y único (ej: "liga-lunes" → "liga-lunes-2" si ya existe)
+- [ ] `status = 'trial'` por default
+- [ ] `organizationId` del usuario actualizado correctamente
+- [ ] Si el usuario ya tiene org, retorna `409`
+
+---
+
+### D3 · Página `/onboarding`
+
+**Labels:** `frontend`
+**Depende de:** D1, D2
+
+**Qué hacer:**
+
+Crear `app/onboarding/page.tsx` (Client Component). Formulario con:
+
+- Nombre de la organización/liga
+- Ciudad
+
+Después de submit exitoso, redirigir a `/admin`.
+
+Contexto visual: explicar brevemente para qué sirve ("Esta será la identidad pública de tu organización en TalachaStats").
+
+**Criterios de aceptación:**
+
+- [ ] No accesible sin sesión (middleware lo protege)
+- [ ] Si el user ya tiene org, redirige directo a `/admin`
+- [ ] Submit crea la org y redirige a `/admin`
+- [ ] Misma estética que login/registro
+
+---
+
+## Epic E — Sistema Trial/Verified
+
+### E1 · Banner trial en el dashboard del organizador
+
+**Labels:** `frontend`
+**Depende de:** A2
+
+**Qué hacer:**
+
+En `app/admin/layout.tsx`, después de obtener el user, obtener su organización y verificar `status`.
+
+Si `status === 'trial'`, mostrar banner amarillo/naranja fijo en la parte superior:
+
+> ⚠️ **Tu liga está en modo de prueba.** Los datos no aparecen en rankings globales.
+> [Solicitar verificación →]
+
+El link abre un modal o redirige a una página de solicitud.
+
+**Criterios de aceptación:**
+
+- [ ] Banner visible solo si `org.status === 'trial'`
+- [ ] No aparece si está verificada
+- [ ] No aparece para `role = 'owner'`
+
+---
+
+### E2 · Endpoint `POST /api/organizations/[id]/request-verification`
+
+**Labels:** `backend`
+**Depende de:** A2
+
+**Qué hacer:**
+
+Crear `app/api/organizations/[id]/request-verification/route.ts`. Flujo:
+
+1. Verificar sesión y que el user pertenece a esa org
+2. Verificar que `status === 'trial'` (no pedir verificación dos veces)
+3. Marcar `verificationRequestedAt = now()`
+4. (Opcional) Enviar email interno a nosotros notificando la solicitud
+5. Retornar éxito
+
+**Criterios de aceptación:**
+
+- [ ] Solo el dueño de la org puede solicitar verificación
+- [ ] Si ya se solicitó, retorna mensaje apropiado (no error, sino "ya enviado")
+- [ ] `verificationRequestedAt` queda guardado en DB
+
+---
+
+### E3 · Badge "Liga en verificación" en páginas públicas
+
+**Labels:** `frontend`
+**Depende de:** A2
+
+**Qué hacer:**
+
+En `app/(public)/org/[slug]/page.tsx` y `app/(public)/org/[slug]/[leagueSlug]/page.tsx`,
+si la organización tiene `status === 'trial'`, mostrar un badge discreto:
+
+```
+🔵 Liga en verificación
+```
+
+Texto pequeño, gris o azul claro, bajo el nombre de la liga. No intrusivo.
+
+**Criterios de aceptación:**
+
+- [ ] Badge visible en org pública y en liga pública si `status === 'trial'`
+- [ ] Desaparece cuando `status === 'verified'`
+- [ ] No afecta el diseño de ligas verificadas
+
+---
+
+### E4 · Filtrar `verified` en queries cross-org
+
+**Labels:** `backend`
+**Depende de:** A2
+
+**Qué hacer:**
+
+En cualquier query que mezcle datos de múltiples organizaciones (rankings globales,
+`/ranking`, listado de ligas públicas `/ligas`), agregar filtro:
+
+```ts
+where: eq(organizations.status, "verified");
+```
+
+Actualmente la Capa 4 no está construida, pero revisar los endpoints existentes
+(`/api/leagues`, `/public/ligas`, `/ranking`) y aplicar el filtro donde corresponda.
+
+**Criterios de aceptación:**
+
+- [ ] `/ligas` (listado público) solo muestra ligas de orgs verificadas
+- [ ] `/ranking` solo incluye jugadores de orgs verificadas
+- [ ] Ligas trial son accesibles por URL directa (no están bloqueadas, solo no se listan)
+
+---
+
+## Epic F — Admin: Gestión de verificaciones
+
+### F1 · Panel `/admin/verifications` — lista de solicitudes pendientes
+
+**Labels:** `frontend`, `backend`, `admin`
+**Depende de:** A2, E2
+
+**Qué hacer:**
+
+Crear `app/admin/verifications/page.tsx`. Server Component que muestra tabla con:
+
+- Nombre de la organización
+- Ciudad
+- Email del dueño
+- Fecha de solicitud
+- Botón "Verificar" y "Rechazar"
+
+Solo accesible para `role = 'owner'`.
+
+Agregar link "Verificaciones" en el nav de admin (solo visible para owners).
+
+**Criterios de aceptación:**
+
+- [ ] Solo owners pueden acceder
+- [ ] Lista orgs con `verificationRequestedAt IS NOT NULL AND status = 'trial'`
+- [ ] Ordenadas por fecha de solicitud (más antiguas primero)
+
+---
+
+### F2 · Endpoint `PATCH /api/organizations/[id]` — aprobar/rechazar
+
+**Labels:** `backend`, `admin`
+**Depende de:** A2
+
+**Qué hacer:**
+
+Crear o extender `app/api/organizations/[id]/route.ts`. Solo `role = 'owner'` puede ejecutar.
+
+Body: `{ status: 'verified' | 'trial' }`
+
+Flujo al verificar:
+
+1. Actualizar `status = 'verified'`
+2. Limpiar `verificationRequestedAt`
+3. (Opcional) Enviar email al organizador notificando la verificación
+
+**Criterios de aceptación:**
+
+- [ ] Solo owners pueden cambiar el status
+- [ ] Cambio es inmediato (no requiere restart)
+- [ ] Email de confirmación al organizador cuando se aprueba
+
+---
+
+### F3 · Email de confirmación al organizador al ser verificado
+
+**Labels:** `email`, `backend`
+**Depende de:** B1, F2
+
+**Qué hacer:**
+
+Crear template en `shared/lib/email-templates.ts`:
+
+```ts
+export function verifiedEmailHtml(params: { orgName: string; dashboardUrl: string }): string;
+```
+
+Enviar desde el endpoint F2 al aprobar.
+
+**Criterios de aceptación:**
+
+- [ ] Email llega al correo del dueño de la org
+- [ ] Menciona el nombre de la org y da el link al dashboard
+- [ ] Tono celebratorio pero profesional
+
+---
+
+## Resumen de historias
+
+| #   | Historia                                            | Epic       | Depende de |
+| --- | --------------------------------------------------- | ---------- | ---------- |
+| A1  | Migración: verificación de email en users           | Schema     | —          |
+| A2  | Migración: status en organizations                  | Schema     | —          |
+| B1  | Configurar Resend                                   | Email      | —          |
+| B2  | Template email de verificación                      | Email      | B1         |
+| C1  | `POST /api/auth/register`                           | Registro   | A1, B2     |
+| C2  | `GET /api/auth/verify-email`                        | Registro   | A1         |
+| C3  | Página `/registro`                                  | Registro   | C1         |
+| C4  | Página `/verificar-email`                           | Registro   | C2         |
+| C5  | Bloquear login si no verificado                     | Registro   | A1         |
+| D1  | Middleware root                                     | Onboarding | A1         |
+| D2  | `POST /api/organizations`                           | Onboarding | A2         |
+| D3  | Página `/onboarding`                                | Onboarding | D1, D2     |
+| E1  | Banner trial en dashboard                           | Trial      | A2         |
+| E2  | `POST /api/organizations/[id]/request-verification` | Trial      | A2         |
+| E3  | Badge en páginas públicas                           | Trial      | A2         |
+| E4  | Filtro verified en queries cross-org                | Trial      | A2         |
+| F1  | Panel `/admin/verifications`                        | Admin      | A2, E2     |
+| F2  | `PATCH /api/organizations/[id]`                     | Admin      | A2         |
+| F3  | Email confirmación al verificar                     | Admin      | B1, F2     |
+
+**Total: 19 historias**
+
+---
+
+## Orden sugerido para PRs
+
+```
+PR 1: A1 + A2  (schema — base de todo)
+PR 2: B1 + B2  (email service)
+PR 3: C1 + C2 + C5  (lógica de registro en backend)
+PR 4: C3 + C4  (UI de registro)
+PR 5: D1 + D2 + D3  (onboarding completo)
+PR 6: E1 + E2 + E3 + E4  (sistema trial/verified)
+PR 7: F1 + F2 + F3  (admin de verificaciones)
+```

--- a/src/db/migrations/0011_public_registration.sql
+++ b/src/db/migrations/0011_public_registration.sql
@@ -1,0 +1,1 @@
+-- Migration superseded by 0012_cool_squirrel_girl.sql (Drizzle auto-generated)

--- a/src/db/migrations/0012_cool_squirrel_girl.sql
+++ b/src/db/migrations/0012_cool_squirrel_girl.sql
@@ -1,0 +1,12 @@
+ALTER TABLE "organizations" ADD COLUMN "status" text DEFAULT 'trial' NOT NULL;--> statement-breakpoint
+ALTER TABLE "organizations" ADD COLUMN "verification_requested_at" timestamp with time zone;--> statement-breakpoint
+ALTER TABLE "users" ADD COLUMN "email_verified" boolean DEFAULT false NOT NULL;--> statement-breakpoint
+ALTER TABLE "users" ADD COLUMN "email_verification_token" text;--> statement-breakpoint
+ALTER TABLE "users" ADD COLUMN "email_verification_expires_at" timestamp with time zone;--> statement-breakpoint
+ALTER TABLE "users" ADD CONSTRAINT "users_email_verification_token_unique" UNIQUE("email_verification_token");
+--> statement-breakpoint
+-- Usuarios existentes ya validados manualmente -> marcar como verificados
+UPDATE "users" SET "email_verified" = true;
+--> statement-breakpoint
+-- Organizaciones existentes son ligas piloto reales -> marcar como verificadas
+UPDATE "organizations" SET "status" = 'verified';

--- a/src/db/migrations/meta/0012_snapshot.json
+++ b/src/db/migrations/meta/0012_snapshot.json
@@ -1,0 +1,1629 @@
+{
+	"id": "6807998e-bdd6-4ad4-b418-bb350c97cf57",
+	"prevId": "0405b40a-be0d-435e-848d-c1b399dd8ed5",
+	"version": "7",
+	"dialect": "postgresql",
+	"tables": {
+		"public.import_audit_log": {
+			"name": "import_audit_log",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true,
+					"default": "gen_random_uuid()"
+				},
+				"league_id": {
+					"name": "league_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"imported_by": {
+					"name": "imported_by",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"import_type": {
+					"name": "import_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"jornada": {
+					"name": "jornada",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"rows_processed": {
+					"name": "rows_processed",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"rows_created": {
+					"name": "rows_created",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"anomaly_summary": {
+					"name": "anomaly_summary",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"warnings": {
+					"name": "warnings",
+					"type": "text[]",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"imported_at": {
+					"name": "imported_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"ial_league_idx": {
+					"name": "ial_league_idx",
+					"columns": [
+						{
+							"expression": "league_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"ial_imported_at_idx": {
+					"name": "ial_imported_at_idx",
+					"columns": [
+						{
+							"expression": "imported_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"ial_jornada_idx": {
+					"name": "ial_jornada_idx",
+					"columns": [
+						{
+							"expression": "league_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "jornada",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"import_audit_log_league_id_leagues_id_fk": {
+					"name": "import_audit_log_league_id_leagues_id_fk",
+					"tableFrom": "import_audit_log",
+					"tableTo": "leagues",
+					"columnsFrom": ["league_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"import_audit_log_imported_by_users_id_fk": {
+					"name": "import_audit_log_imported_by_users_id_fk",
+					"tableFrom": "import_audit_log",
+					"tableTo": "users",
+					"columnsFrom": ["imported_by"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.import_templates": {
+			"name": "import_templates",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true,
+					"default": "gen_random_uuid()"
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"type": {
+					"name": "type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"header_row": {
+					"name": "header_row",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"column_map": {
+					"name": "column_map",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.leagues": {
+			"name": "leagues",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true,
+					"default": "gen_random_uuid()"
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"slug": {
+					"name": "slug",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"category": {
+					"name": "category",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"day_of_week": {
+					"name": "day_of_week",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"season": {
+					"name": "season",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"city": {
+					"name": "city",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'Tijuana'"
+				},
+				"organization_id": {
+					"name": "organization_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'active'"
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"leagues_organization_id_organizations_id_fk": {
+					"name": "leagues_organization_id_organizations_id_fk",
+					"tableFrom": "leagues",
+					"tableTo": "organizations",
+					"columnsFrom": ["organization_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.match_events": {
+			"name": "match_events",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true,
+					"default": "gen_random_uuid()"
+				},
+				"match_id": {
+					"name": "match_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"player_id": {
+					"name": "player_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"team_id": {
+					"name": "team_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"event_type": {
+					"name": "event_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"minute": {
+					"name": "minute",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"events_match_idx": {
+					"name": "events_match_idx",
+					"columns": [
+						{
+							"expression": "match_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"events_player_idx": {
+					"name": "events_player_idx",
+					"columns": [
+						{
+							"expression": "player_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"events_type_idx": {
+					"name": "events_type_idx",
+					"columns": [
+						{
+							"expression": "event_type",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"match_events_match_id_matches_id_fk": {
+					"name": "match_events_match_id_matches_id_fk",
+					"tableFrom": "match_events",
+					"tableTo": "matches",
+					"columnsFrom": ["match_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"match_events_player_id_players_id_fk": {
+					"name": "match_events_player_id_players_id_fk",
+					"tableFrom": "match_events",
+					"tableTo": "players",
+					"columnsFrom": ["player_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"match_events_team_id_teams_id_fk": {
+					"name": "match_events_team_id_teams_id_fk",
+					"tableFrom": "match_events",
+					"tableTo": "teams",
+					"columnsFrom": ["team_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.matches": {
+			"name": "matches",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true,
+					"default": "gen_random_uuid()"
+				},
+				"league_id": {
+					"name": "league_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"home_team_id": {
+					"name": "home_team_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"away_team_id": {
+					"name": "away_team_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"match_date": {
+					"name": "match_date",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"matchday": {
+					"name": "matchday",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'scheduled'"
+				},
+				"home_score": {
+					"name": "home_score",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"away_score": {
+					"name": "away_score",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"notes": {
+					"name": "notes",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"matches_league_idx": {
+					"name": "matches_league_idx",
+					"columns": [
+						{
+							"expression": "league_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"matches_date_idx": {
+					"name": "matches_date_idx",
+					"columns": [
+						{
+							"expression": "match_date",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"matches_status_idx": {
+					"name": "matches_status_idx",
+					"columns": [
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"matches_league_id_leagues_id_fk": {
+					"name": "matches_league_id_leagues_id_fk",
+					"tableFrom": "matches",
+					"tableTo": "leagues",
+					"columnsFrom": ["league_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"matches_home_team_id_teams_id_fk": {
+					"name": "matches_home_team_id_teams_id_fk",
+					"tableFrom": "matches",
+					"tableTo": "teams",
+					"columnsFrom": ["home_team_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"matches_away_team_id_teams_id_fk": {
+					"name": "matches_away_team_id_teams_id_fk",
+					"tableFrom": "matches",
+					"tableTo": "teams",
+					"columnsFrom": ["away_team_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.organizations": {
+			"name": "organizations",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true,
+					"default": "gen_random_uuid()"
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"slug": {
+					"name": "slug",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"logo_url": {
+					"name": "logo_url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"city": {
+					"name": "city",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'Tijuana'"
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'trial'"
+				},
+				"verification_requested_at": {
+					"name": "verification_requested_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"organizations_slug_idx": {
+					"name": "organizations_slug_idx",
+					"columns": [
+						{
+							"expression": "slug",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"organizations_slug_unique": {
+					"name": "organizations_slug_unique",
+					"nullsNotDistinct": false,
+					"columns": ["slug"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.page_views": {
+			"name": "page_views",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true,
+					"default": "gen_random_uuid()"
+				},
+				"visitor_id": {
+					"name": "visitor_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"page": {
+					"name": "page",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"visited_at": {
+					"name": "visited_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"pv_visitor_idx": {
+					"name": "pv_visitor_idx",
+					"columns": [
+						{
+							"expression": "visitor_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"pv_page_idx": {
+					"name": "pv_page_idx",
+					"columns": [
+						{
+							"expression": "page",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"pv_visited_at_idx": {
+					"name": "pv_visited_at_idx",
+					"columns": [
+						{
+							"expression": "visited_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.player_registrations": {
+			"name": "player_registrations",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true,
+					"default": "gen_random_uuid()"
+				},
+				"player_id": {
+					"name": "player_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"team_id": {
+					"name": "team_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"league_id": {
+					"name": "league_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"jersey_number": {
+					"name": "jersey_number",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"registered_at": {
+					"name": "registered_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"registrations_player_idx": {
+					"name": "registrations_player_idx",
+					"columns": [
+						{
+							"expression": "player_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"registrations_team_idx": {
+					"name": "registrations_team_idx",
+					"columns": [
+						{
+							"expression": "team_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"registrations_league_idx": {
+					"name": "registrations_league_idx",
+					"columns": [
+						{
+							"expression": "league_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"player_registrations_player_id_players_id_fk": {
+					"name": "player_registrations_player_id_players_id_fk",
+					"tableFrom": "player_registrations",
+					"tableTo": "players",
+					"columnsFrom": ["player_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"player_registrations_team_id_teams_id_fk": {
+					"name": "player_registrations_team_id_teams_id_fk",
+					"tableFrom": "player_registrations",
+					"tableTo": "teams",
+					"columnsFrom": ["team_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"player_registrations_league_id_leagues_id_fk": {
+					"name": "player_registrations_league_id_leagues_id_fk",
+					"tableFrom": "player_registrations",
+					"tableTo": "leagues",
+					"columnsFrom": ["league_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"unique_player_per_league": {
+					"name": "unique_player_per_league",
+					"nullsNotDistinct": false,
+					"columns": ["player_id", "league_id"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.player_season_stats": {
+			"name": "player_season_stats",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true,
+					"default": "gen_random_uuid()"
+				},
+				"player_id": {
+					"name": "player_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"league_id": {
+					"name": "league_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"team_id": {
+					"name": "team_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"matches_played": {
+					"name": "matches_played",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"goals": {
+					"name": "goals",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"assists": {
+					"name": "assists",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"yellow_cards": {
+					"name": "yellow_cards",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"red_cards": {
+					"name": "red_cards",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"jornada": {
+					"name": "jornada",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"pss_player_idx": {
+					"name": "pss_player_idx",
+					"columns": [
+						{
+							"expression": "player_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"pss_league_idx": {
+					"name": "pss_league_idx",
+					"columns": [
+						{
+							"expression": "league_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"player_season_stats_player_id_players_id_fk": {
+					"name": "player_season_stats_player_id_players_id_fk",
+					"tableFrom": "player_season_stats",
+					"tableTo": "players",
+					"columnsFrom": ["player_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"player_season_stats_league_id_leagues_id_fk": {
+					"name": "player_season_stats_league_id_leagues_id_fk",
+					"tableFrom": "player_season_stats",
+					"tableTo": "leagues",
+					"columnsFrom": ["league_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"player_season_stats_team_id_teams_id_fk": {
+					"name": "player_season_stats_team_id_teams_id_fk",
+					"tableFrom": "player_season_stats",
+					"tableTo": "teams",
+					"columnsFrom": ["team_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"unique_player_season": {
+					"name": "unique_player_season",
+					"nullsNotDistinct": false,
+					"columns": ["player_id", "league_id"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.player_season_stats_snapshot": {
+			"name": "player_season_stats_snapshot",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true,
+					"default": "gen_random_uuid()"
+				},
+				"player_id": {
+					"name": "player_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"league_id": {
+					"name": "league_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"team_id": {
+					"name": "team_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"jornada": {
+					"name": "jornada",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"goals": {
+					"name": "goals",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"assists": {
+					"name": "assists",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"yellow_cards": {
+					"name": "yellow_cards",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"red_cards": {
+					"name": "red_cards",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"matches_played": {
+					"name": "matches_played",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"imported_at": {
+					"name": "imported_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"psss_player_idx": {
+					"name": "psss_player_idx",
+					"columns": [
+						{
+							"expression": "player_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"psss_league_idx": {
+					"name": "psss_league_idx",
+					"columns": [
+						{
+							"expression": "league_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"psss_jornada_idx": {
+					"name": "psss_jornada_idx",
+					"columns": [
+						{
+							"expression": "jornada",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"player_season_stats_snapshot_player_id_players_id_fk": {
+					"name": "player_season_stats_snapshot_player_id_players_id_fk",
+					"tableFrom": "player_season_stats_snapshot",
+					"tableTo": "players",
+					"columnsFrom": ["player_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"player_season_stats_snapshot_league_id_leagues_id_fk": {
+					"name": "player_season_stats_snapshot_league_id_leagues_id_fk",
+					"tableFrom": "player_season_stats_snapshot",
+					"tableTo": "leagues",
+					"columnsFrom": ["league_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"player_season_stats_snapshot_team_id_teams_id_fk": {
+					"name": "player_season_stats_snapshot_team_id_teams_id_fk",
+					"tableFrom": "player_season_stats_snapshot",
+					"tableTo": "teams",
+					"columnsFrom": ["team_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"unique_player_league_jornada_snap": {
+					"name": "unique_player_league_jornada_snap",
+					"nullsNotDistinct": false,
+					"columns": ["player_id", "league_id", "jornada"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.players": {
+			"name": "players",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true,
+					"default": "gen_random_uuid()"
+				},
+				"full_name": {
+					"name": "full_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"alias": {
+					"name": "alias",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"phone": {
+					"name": "phone",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"photo_url": {
+					"name": "photo_url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.team_standings_snapshot": {
+			"name": "team_standings_snapshot",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true,
+					"default": "gen_random_uuid()"
+				},
+				"team_id": {
+					"name": "team_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"league_id": {
+					"name": "league_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"jornada": {
+					"name": "jornada",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"played": {
+					"name": "played",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"wins": {
+					"name": "wins",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"draws": {
+					"name": "draws",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"losses": {
+					"name": "losses",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"goals_for": {
+					"name": "goals_for",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"goals_against": {
+					"name": "goals_against",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"points": {
+					"name": "points",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"zone": {
+					"name": "zone",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"tss_league_idx": {
+					"name": "tss_league_idx",
+					"columns": [
+						{
+							"expression": "league_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"tss_jornada_idx": {
+					"name": "tss_jornada_idx",
+					"columns": [
+						{
+							"expression": "jornada",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"team_standings_snapshot_team_id_teams_id_fk": {
+					"name": "team_standings_snapshot_team_id_teams_id_fk",
+					"tableFrom": "team_standings_snapshot",
+					"tableTo": "teams",
+					"columnsFrom": ["team_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"team_standings_snapshot_league_id_leagues_id_fk": {
+					"name": "team_standings_snapshot_league_id_leagues_id_fk",
+					"tableFrom": "team_standings_snapshot",
+					"tableTo": "leagues",
+					"columnsFrom": ["league_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"unique_team_jornada": {
+					"name": "unique_team_jornada",
+					"nullsNotDistinct": false,
+					"columns": ["team_id", "league_id", "jornada"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.teams": {
+			"name": "teams",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true,
+					"default": "gen_random_uuid()"
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"league_id": {
+					"name": "league_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"color": {
+					"name": "color",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"teams_league_idx": {
+					"name": "teams_league_idx",
+					"columns": [
+						{
+							"expression": "league_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"teams_league_id_leagues_id_fk": {
+					"name": "teams_league_id_leagues_id_fk",
+					"tableFrom": "teams",
+					"tableTo": "leagues",
+					"columnsFrom": ["league_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.users": {
+			"name": "users",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true,
+					"default": "gen_random_uuid()"
+				},
+				"email": {
+					"name": "email",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"password_hash": {
+					"name": "password_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"role": {
+					"name": "role",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'organizer'"
+				},
+				"active": {
+					"name": "active",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": true
+				},
+				"organization_id": {
+					"name": "organization_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"email_verified": {
+					"name": "email_verified",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"email_verification_token": {
+					"name": "email_verification_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"email_verification_expires_at": {
+					"name": "email_verification_expires_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"users_email_idx": {
+					"name": "users_email_idx",
+					"columns": [
+						{
+							"expression": "email",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"users_organization_idx": {
+					"name": "users_organization_idx",
+					"columns": [
+						{
+							"expression": "organization_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"users_organization_id_organizations_id_fk": {
+					"name": "users_organization_id_organizations_id_fk",
+					"tableFrom": "users",
+					"tableTo": "organizations",
+					"columnsFrom": ["organization_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"users_email_unique": {
+					"name": "users_email_unique",
+					"nullsNotDistinct": false,
+					"columns": ["email"]
+				},
+				"users_email_verification_token_unique": {
+					"name": "users_email_verification_token_unique",
+					"nullsNotDistinct": false,
+					"columns": ["email_verification_token"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		}
+	},
+	"enums": {},
+	"schemas": {},
+	"sequences": {},
+	"roles": {},
+	"policies": {},
+	"views": {},
+	"_meta": {
+		"columns": {},
+		"schemas": {},
+		"tables": {}
+	}
+}

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -78,6 +78,20 @@
 			"when": 1777585291433,
 			"tag": "0010_parallel_sharon_ventura",
 			"breakpoints": true
+		},
+		{
+			"idx": 11,
+			"version": "7",
+			"when": 1746000000000,
+			"tag": "0011_public_registration",
+			"breakpoints": true
+		},
+		{
+			"idx": 12,
+			"version": "7",
+			"when": 1777605295507,
+			"tag": "0012_cool_squirrel_girl",
+			"breakpoints": true
 		}
 	]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -24,6 +24,12 @@ export const organizations = pgTable(
 		slug: text("slug").notNull().unique(), // URL-friendly: "novofut", "casablanca-fc"
 		logoUrl: text("logo_url"),
 		city: text("city").notNull().default("Tijuana"),
+		// "trial" = recién registrada, datos no aparecen en vistas cross-org
+		// "verified" = verificada manualmente, aparece en rankings globales
+		status: text("status").notNull().default("trial"), // "trial" | "verified"
+		verificationRequestedAt: timestamp("verification_requested_at", {
+			withTimezone: true,
+		}),
 		createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
 	},
 	(t) => [index("organizations_slug_idx").on(t.slug)],
@@ -31,6 +37,8 @@ export const organizations = pgTable(
 
 export type Organization = typeof organizations.$inferSelect;
 export type NewOrganization = typeof organizations.$inferInsert;
+export const ORG_STATUSES = ["trial", "verified"] as const;
+export type OrgStatus = (typeof ORG_STATUSES)[number];
 
 // ---------------------------------------------------------------------------
 // USERS — Cuentas de acceso al panel admin
@@ -48,6 +56,12 @@ export const users = pgTable(
 		active: boolean("active").notNull().default(true),
 		organizationId: uuid("organization_id").references(() => organizations.id, {
 			onDelete: "set null",
+		}),
+		// Verificación de email — requerida para acceder al panel
+		emailVerified: boolean("email_verified").notNull().default(false),
+		emailVerificationToken: text("email_verification_token").unique(),
+		emailVerificationExpiresAt: timestamp("email_verification_expires_at", {
+			withTimezone: true,
 		}),
 		createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
 	},

--- a/src/entities/user/index.ts
+++ b/src/entities/user/index.ts
@@ -1,5 +1,12 @@
-export type { UserPublic, UserRole, CreateUserInput, UpdateUserInput, LoginInput } from "./model";
-export { CreateUserSchema, UpdateUserSchema, LoginSchema } from "./model";
+export type {
+	UserPublic,
+	UserRole,
+	CreateUserInput,
+	UpdateUserInput,
+	LoginInput,
+	RegisterInput,
+} from "./model";
+export { CreateUserSchema, UpdateUserSchema, LoginSchema, RegisterSchema } from "./model";
 export {
 	getUserById,
 	getUserByEmail,

--- a/src/entities/user/model.ts
+++ b/src/entities/user/model.ts
@@ -3,9 +3,9 @@
  * Tipos del dominio para usuarios del panel admin.
  *
  * Roles:
- *  - "owner"     → superadmin, ve y edita todo sin restricción
- *  - "organizer" → solo gestiona las ligas donde es adminId
- *  - "player"    → reservado para el futuro acceso de jugadores
+ *  - "owner"     -> superadmin, ve y edita todo sin restriccion
+ *  - "organizer" -> solo gestiona las ligas de su organizacion
+ *  - "player"    -> reservado para el futuro acceso de jugadores
  */
 import { z } from "zod";
 
@@ -17,14 +17,16 @@ export type UserPublic = {
 	name: string;
 	role: UserRole;
 	active: boolean;
+	emailVerified: boolean;
+	organizationId: string | null;
 	createdAt: Date;
 };
 
-// ── Schemas Zod ───────────────────────────────────────────────────────────────
+// -- Schemas Zod --------------------------------------------------------------
 
 export const CreateUserSchema = z.object({
-	email: z.string().email("Email inválido").toLowerCase(),
-	password: z.string().min(8, "Mínimo 8 caracteres"),
+	email: z.string().email("Email invalido").toLowerCase(),
+	password: z.string().min(8, "Minimo 8 caracteres"),
 	name: z.string().min(2).max(80),
 	role: z.enum(["owner", "organizer"]).default("organizer"),
 });
@@ -41,6 +43,13 @@ export const LoginSchema = z.object({
 	password: z.string().min(1),
 });
 
+export const RegisterSchema = z.object({
+	name: z.string().min(2, "Minimo 2 caracteres").max(80),
+	email: z.string().email("Email invalido").toLowerCase(),
+	password: z.string().min(8, "Minimo 8 caracteres"),
+});
+
 export type CreateUserInput = z.infer<typeof CreateUserSchema>;
 export type UpdateUserInput = z.infer<typeof UpdateUserSchema>;
 export type LoginInput = z.infer<typeof LoginSchema>;
+export type RegisterInput = z.infer<typeof RegisterSchema>;

--- a/src/entities/user/queries.ts
+++ b/src/entities/user/queries.ts
@@ -89,6 +89,8 @@ function toPublic(u: typeof users.$inferSelect): UserPublic {
 		name: u.name,
 		role: u.role as UserPublic["role"],
 		active: u.active,
+		emailVerified: u.emailVerified,
+		organizationId: u.organizationId ?? null,
 		createdAt: u.createdAt,
 	};
 }


### PR DESCRIPTION
…/verified

A1 — users:
- Agrega email_verified (bool, default false)
- Agrega email_verification_token (text, unique, nullable)
- Agrega email_verification_expires_at (timestamptz, nullable)
- Usuarios existentes marcados como email_verified = true en migracion

A2 — organizations:
- Agrega status (trial|verified, default trial)
- Agrega verification_requested_at (timestamptz, nullable)
- Orgs existentes marcadas como status = verified en migracion
- Exporta ORG_STATUSES y OrgStatus

entities/user:
- UserPublic incluye emailVerified y organizationId
- Agrega RegisterSchema y RegisterInput
- toPublic() retorna los campos nuevos

Migracion: 0012_cool_squirrel_girl.sql (Drizzle auto-gen + UPDATEs de datos)

Closes A1, A2 del roadmap