### PR TITLE
fix(discipline): pasar tx explícita a findleagueconfigordefaults para…

### DIFF
--- a/src/entities/league-config/queries.ts
+++ b/src/entities/league-config/queries.ts
@@ -26,9 +26,18 @@ export const LEAGUE_CONFIG_DTO_COLUMNS = {
 	lockedAt: leagueConfig.lockedAt,
 } as const;
 
-/** Fila cruda de league_config, o null si la liga nunca la ha guardado. */
-export async function findLeagueConfig(leagueId: string): Promise<LeagueConfigDto | null> {
-	const rows = await db
+/**
+ * Fila cruda de league_config, o null si la liga nunca la ha guardado.
+ * Acepta `client` para poder correr dentro de una tx abierta (p. ej. el motor
+ * de disciplina llamado desde `resolveMatch`) — con pool `max: 1` en
+ * producción, usar el `db` global aquí dentro de una tx abierta bloquea la
+ * única conexión esperándose a sí misma hasta `connectionTimeoutMillis`.
+ */
+export async function findLeagueConfig(
+	leagueId: string,
+	client: DbOrTx = db,
+): Promise<LeagueConfigDto | null> {
+	const rows = await client
 		.select(LEAGUE_CONFIG_DTO_COLUMNS)
 		.from(leagueConfig)
 		.where(eq(leagueConfig.leagueId, leagueId))
@@ -41,8 +50,11 @@ export async function findLeagueConfig(leagueId: string): Promise<LeagueConfigDt
  * (informal que nunca abrió "Reglamento del torneo"). Usar aquí, no en
  * `standings.ts`, para no repetir los defaults del schema por todo el código.
  */
-export async function findLeagueConfigOrDefaults(leagueId: string): Promise<LeagueConfigDto> {
-	const config = await findLeagueConfig(leagueId);
+export async function findLeagueConfigOrDefaults(
+	leagueId: string,
+	client: DbOrTx = db,
+): Promise<LeagueConfigDto> {
+	const config = await findLeagueConfig(leagueId, client);
 	if (config) return config;
 	return {
 		leagueId,

--- a/src/features/discipline/apply-card-discipline.ts
+++ b/src/features/discipline/apply-card-discipline.ts
@@ -171,7 +171,7 @@ export async function applyCardDiscipline(
 	const cardedPlayers = await findCardedPlayersInMatch(tx, matchId);
 	if (cardedPlayers.length === 0) return;
 
-	const config = await findLeagueConfigOrDefaults(leagueId);
+	const config = await findLeagueConfigOrDefaults(leagueId, tx);
 
 	for (const player of cardedPlayers) {
 		if (player.redCards > 0) {


### PR DESCRIPTION
… evitar deadlock del pool

En apply-card-discipline.ts, dentro de la transacción de resolveMatch, findLeagueConfigOrDefaults() usaba el cliente `db` global en vez del `tx` recibido. Con pool `max: 1` en producción (serverless, una conexión por invocación), la transacción abierta ya retenía la única conexión disponible; la query de league_config pedía una segunda conexión al mismo pool y nunca la obtenía, agotando connectionTimeoutMillis (10s) y tumbando la resolución de la cédula.

Solo se reproducía cuando la cédula resuelta incluía tarjetas (amarilla o roja), que es lo único que dispara applyCardDiscipline.

- findLeagueConfig / findLeagueConfigOrDefaults aceptan ahora un `client` opcional (DbOrTx), mismo patrón que insertLeagueConfig.
- apply-card-discipline.ts pasa `tx` explícitamente.
- Callers fuera de una tx (standings.ts, tournament-rules/rules.ts, new-season/route.ts) no cambian: siguen usando `db` por default.